### PR TITLE
Convert CamelCased suite names to Title Cased suite names

### DIFF
--- a/app/assets/javascripts/views/templates/servers/failures_report.hbs
+++ b/app/assets/javascripts/views/templates/servers/failures_report.hbs
@@ -38,7 +38,7 @@
                           Suite
                         </div>
                         <div class="col-md-8 test-stats-suite">
-                          {{failure.suite.name}}
+                          {{title-case failure.suite.name}}
                         </div>
                       {{/if}}
                       {{#if failure.requires}}

--- a/app/assets/javascripts/views/templates/servers/suite_select.hbs
+++ b/app/assets/javascripts/views/templates/servers/suite_select.hbs
@@ -3,7 +3,7 @@
     <h4 class="panel-title">
       <input type="checkbox" name="{{suite.id}}">
       <a class="collapsed" data-toggle="collapse" aria-expanded="false" data-target="#{{suite.id}}_details">
-      <label>{{suite.name}}</label>
+      <label>{{title-case suite.name}}</label>
       </a>
       <span class="test-status">
       </span>


### PR DESCRIPTION
Using the `Case` NPM lib, we can change CamelCased suite names, such as `ConnectathonAuditEventandProvenanceTrackTest`, into Title Cased suite names, such as `Connectathon Audit Event and Provenance Track Test`. 
