### PR TITLE
Fix to rake crucible:test_all summary bug

### DIFF
--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -36,26 +36,26 @@ module Aggregate
     build_compliance_node_map(compliance, node_map)
     server.aggregate_run.results.each do |result|
       result['validates'].each do |validation|
-        if validation['resource']
-          update_node(node_map, validation['resource'].titleize.downcase, result)
+        if validation[:resource]
+          update_node(node_map, validation[:resource].titleize.downcase, result)
         end
-        if validation['methods']
-          validation['methods'].each do |method|
+        if validation[:methods]
+          validation[:methods].each do |method|
             update_node(node_map, method, result)
           end
         end
-        if validation['formats']
-          validation['formats'].each do |format|
+        if validation[:formats]
+          validation[:formats].each do |format|
             update_node(node_map, format, result)
           end
         end
-        if validation['extensions']
-          validation['extensions'].each do |extension|
+        if validation[:extensions]
+          validation[:extensions].each do |extension|
             update_node(node_map, extension, result)
           end
         end
-        if validation['profiles']
-          validation['profiles'].each do |profile|
+        if validation[:profiles]
+          validation[:profiles].each do |profile|
             update_node(node_map, profile, result)
           end
         end


### PR DESCRIPTION
This fixes the bug that prevents the summary from being properly generated when rake crucible:test_all is run.  I tested it for both the rake task and using the web interface.

This could probably be fixed in the spot that generates the "validates" hash instead, which I think is in the plan_executor gem, but it will take me awhile to understand that code well enough to be confident to change it.
