### PR TITLE
Fixed URL duplication issues, by persisting the normalized URL

### DIFF
--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -6,10 +6,11 @@ class ServersController < ApplicationController
   end
 
   def create
-    url = PostRank::URI.normalize(params['server']['url'])
+    url = PostRank::URI.normalize(params['server']['url']).to_s.chop
     server = Server.where(url: url).first
     unless server
-      server = Server.new(params.require(:server).permit(:url, :name))
+      server = Server.new(params.require(:server).permit(:name))
+      server.url = url
       server.save
     end
     redirect_to action: "show", id: server.id
@@ -18,7 +19,6 @@ class ServersController < ApplicationController
   def oauth_redirect
     server = Server.where(state: params[:state]).first
     if server
-      # server.oauth_code = params[:code]
       options = {
         authorize_url: server.authorize_url,
         token_url: server.token_url,

--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -16,7 +16,7 @@ class TestsController < ApplicationController
   def execute
     @server = Server.find(params[:server_id])
     client1 = FHIR::Client.new(@server.url)
-    if @server.oauth_code
+    if @server.oauth_token_opts
       client1.client = @server.get_oauth2_client
       client1.use_oauth2_auth = true
     end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -9,7 +9,6 @@ class Server
   field :percent_passing, type: Float
   field :conformance, type: String
   field :state, type: String
-  field :oauth_code, type: String
   field :client_id, type: String
   field :client_secret, type: String
   field :authorize_url, type: String


### PR DESCRIPTION
 (with the trailing space removed, as expected by the FHIR Client) rather than the non-normalized URL. Also fixed the OAuth2 issues
