### PR TITLE
Updated authorization.coffee to not use Array.prototype.find 

### DIFF
--- a/app/assets/javascripts/views/component/authorization.coffee
+++ b/app/assets/javascripts/views/component/authorization.coffee
@@ -16,7 +16,7 @@ class Crucible.Authorization
         authUrl = conformance_tab.data('authorize-url')
         $('#authorize_form').attr("action", authUrl)
     )
-    @element.find("#authorize_form").on('submit', (event) =>
+    $("#authorize_form").on('submit', (event) =>
       event.preventDefault()
       $.post("/servers/#{$('#conformance-data').data('server-id')}/oauth_params",
       {


### PR DESCRIPTION
Since it's not really supported yet (and wasn't really what we wanted to begin with), I removed Array.prototype.find, and used a jQuery selector for the ID of the authorize form. 
