### PR TITLE
Only request the conformance if there's actually a server ID

### DIFF
--- a/app/assets/javascripts/views/component/conformance.coffee
+++ b/app/assets/javascripts/views/component/conformance.coffee
@@ -9,7 +9,7 @@ class Crucible.Conformance
     @element = $('#conformance-data')
     @template = HandlebarsTemplates['views/templates/servers/conformance']
     @serverId = @element.data('server-id')
-    @loadConformance()
+    @loadConformance() if @serverId?
 
   loadConformance: (refresh) =>
     refreshParam = if refresh then '?refresh=true' else ''

--- a/app/assets/javascripts/views/component/conformance.coffee
+++ b/app/assets/javascripts/views/component/conformance.coffee
@@ -7,9 +7,10 @@ class Crucible.Conformance
 
   constructor: ->
     @element = $('#conformance-data')
+    return unless @element.length
     @template = HandlebarsTemplates['views/templates/servers/conformance']
     @serverId = @element.data('server-id')
-    @loadConformance() if @serverId?
+    @loadConformance()
 
   loadConformance: (refresh) =>
     refreshParam = if refresh then '?refresh=true' else ''

--- a/app/assets/javascripts/views/component/conformance.coffee
+++ b/app/assets/javascripts/views/component/conformance.coffee
@@ -25,6 +25,7 @@ class Crucible.Conformance
       )
       .error ((data) =>
         @removeConformanceSpinner()
+        @element.html('<div class="alert" role="alert"><div class="alert alert-danger"><strong>Error: </strong> Conformance Statement could not be loaded</div></div>')
       )
     )
 


### PR DESCRIPTION
Currently, `conformance.coffee` requests the conformance for the current server on every page load, even if there isn't a server to request the conformance for. This change makes it so that the conformance is only loaded if there's a server ID present on the page.
