### PR TITLE
Only look for the OAuth2 data if there are security extensions

### DIFF
--- a/app/assets/javascripts/views/component/conformance.coffee
+++ b/app/assets/javascripts/views/component/conformance.coffee
@@ -54,7 +54,7 @@ class Crucible.Conformance
       auth.value.value
 
   authType: =>
-      if @conformance.rest[0].security
+      if @conformance.rest[0].security && @conformance.rest[0].security.extension
         switch @conformance.rest[0].security.extension[0].url
           when "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris" then "OAuth2"
       else


### PR DESCRIPTION
Issue: If there were SMART REST security statements in the conformance (`@conformance.rest[0].security`), but no extensions to that statement (@conformance.rest[0].security.extension) the `authType` method in `conformance.coffee` would error out. This adds a clause to check for the existence of the extensions before switching through the URLs
