### PR TITLE
Added div closure to modal 

### DIFF
--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -186,6 +186,7 @@
           <div>
               Are you sure you want to cancel this test run?
           </div>
+        </div>
       </div>
       <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
This way, the footer is properly outside of the body of the page, and spans the width of the window. Before it was limited to the width of the page container.
