### PR TITLE
change logging for delayed job

### DIFF
--- a/app/jobs/run_tests_job.rb
+++ b/app/jobs/run_tests_job.rb
@@ -3,10 +3,11 @@ class RunTestsJob < ActiveJob::Base
 
   def perform(test_run_id)
 
-    Rails.logger.debug "#{self.class.name}: Starting Test Run #{test_run_id}"
+    Delayed::Worker.logger.info "#{self.class.name}: Starting Test Run #{test_run_id}"
     testrun = TestRun.find(test_run_id)
+    Delayed::Worker.logger.info "Test Run #{test_run_id}: #{testrun.try(:server).try(:name)}: #{testrun.try(:server).try(:url)}" 
     testrun.execute()
-    Rails.logger.debug "#{self.class.name}: Finished Test Run #{test_run_id}"
+    Delayed::Worker.logger.info "#{self.class.name}: Finished Test Run #{test_run_id}"
 
   end
 end


### PR DESCRIPTION
change the logging for delayed job to log to a separate file.  This allows the delayed job log to be separated from the rest of the rails logging
