### PR TITLE
Allow refresh of a broken conformance

### DIFF
--- a/app/assets/javascripts/views/component/conformance.coffee
+++ b/app/assets/javascripts/views/component/conformance.coffee
@@ -4,6 +4,8 @@ $(window).on('load', ->
 
 class Crucible.Conformance
   @operations: ["read", "vread", "update", "delete", "history-instance", "validate", "history-type", "create", "search-type"]
+  templates:
+    conformanceError: 'views/templates/servers/conformance_error'
 
   constructor: ->
     @element = $('#conformance-data')
@@ -19,14 +21,16 @@ class Crucible.Conformance
       .success ((data) =>
         @updateConformance(data)
         @removeConformanceSpinner()
-        @element.find('#refresh-conformance-link').click =>
-          $("#conformance_spinner").show()
-          @loadConformance(true)
       )
       .error ((data) =>
         @removeConformanceSpinner()
-        @element.html('<div class="alert" role="alert"><div class="alert alert-danger"><strong>Error: </strong> Conformance Statement could not be loaded</div></div>')
+        @element.html(HandlebarsTemplates[@templates.conformanceError]())
       )
+      .complete () =>
+        @element.find('#refresh-conformance-link').click =>
+          $("#conformance_spinner").show()
+          @loadConformance(true)
+
     )
 
   updateConformance: (data)=>

--- a/app/assets/javascripts/views/templates/servers/conformance_error.hbs
+++ b/app/assets/javascripts/views/templates/servers/conformance_error.hbs
@@ -1,0 +1,8 @@
+<a id="refresh-conformance-link" href="#">
+  <i class="glyphicon glyphicon glyphicon-refresh"></i>&nbsp;Refresh Cached Conformance
+</a>
+<div class="alert" role="alert">
+	<div class="alert alert-danger">
+		<strong>Error: </strong> Conformance Statement could not be loaded
+	</div>
+</div>


### PR DESCRIPTION
currently conformance statements do not allow refresh when there is an error in the conformance.  If the json gets stored, then there is no way to recover.  This adds the refresh link in when there is an error

https://www.pivotaltracker.com/story/show/106946364
