### PR TITLE
Fix cancel test run modal

### DIFF
--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -184,13 +184,13 @@
         </div>
         <div class="modal-body">
           <div>
-              Are you sure you want to cancel this test run?
+            Are you sure you want to cancel this test run?
           </div>
         </div>
-      </div>
-      <div class="modal-footer">
+        <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
           <button type="button" class="btn btn-primary" id="cancel-confirm">Cancel Test Run</button>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I just moved a div that was added in #63 down a few lines to fix the styling of the cancel modal.

Before: 
![screen shot 2015-11-12 at 3 22 57 pm](https://cloud.githubusercontent.com/assets/412901/11130230/e7bb2a52-8951-11e5-8342-6cc53ec08858.png)

After:
![screen shot 2015-11-12 at 3 24 39 pm](https://cloud.githubusercontent.com/assets/412901/11130234/efc32f60-8951-11e5-8c4e-8dbfb8e65adc.png)
