### PR TITLE
Makes use of a refresh token, if the current token is expired

### DIFF
--- a/app/assets/javascripts/views/component/test-executor.coffee
+++ b/app/assets/javascripts/views/component/test-executor.coffee
@@ -17,6 +17,7 @@ class Crucible.TestExecutor
     spinner: '<span class="fa fa-lg fa-fw fa-spinner fa-pulse tests"></span>'
     unavailableError: '<div class="alert alert-danger"><strong>Error: </strong> Server Unavailable</div>'
     genericError: '<div class="alert alert-danger"><strong>Error: </strong> Tests could not be executed</div>'
+    unauthorizedError: '<div class="alert alert-danger"><strong>Error: Server unauthorized or authorization expired</strong></div>'
   filters:
     search: ""
     executed: false
@@ -218,6 +219,9 @@ class Crucible.TestExecutor
         @filter()
       if test_run.status == "unavailable"
         @displayError(@html.unavailableError)
+        @element.dequeue("executionQueue")
+      else if test_run.status == "unauthorized"
+        @displayError(@html.unauthorizedError)
         @element.dequeue("executionQueue")
       else if test_run.status == "error"
         @displayError(@html.genericError)

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -46,6 +46,19 @@ class Server
     }
     client = OAuth2::Client.new(self.client_id, self.client_secret, options)
     token = OAuth2::AccessToken.from_hash(client, self.oauth_token_opts)
+    if token.expired?
+      if token.refresh_token
+        token = token.refresh!
+        if token
+          self.oauth_token_opts = token.to_hash
+          self.save!
+        else
+          return nil
+        end
+      else
+        return nil
+      end
+    end
     return token
   end
 

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -28,6 +28,15 @@ class TestRun
     client1 = FHIR::Client.new(self.server.url)
     if self.server.oauth_token_opts
       client1.client = self.server.get_oauth2_client
+      if client1.client.nil?
+        self.status = 'unauthorized'
+        self.save
+
+        return false
+      end
+      # If the token had to get refreshed, the server oauth details are probably out of sync here
+      # So we'll reload the server to keep it in sync, since we save it later in this function
+      self.server.reload
       client1.use_oauth2_auth = true
     end
     # client2 = FHIR::Client.new(result.test_run.destination_server.url) if result.test_run.is_multiserver


### PR DESCRIPTION
But only if one is present. If it isn't, or the refresh fails, let the user know the server isn't authorized anymore.
