### PR TITLE
filter tests by those supported by the conformance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/fhir-crucible/plan_executor.git
-  revision: 49f1784b28515c9c158ad0757734ca19fe1b413a
+  revision: 549f6fb4ef3b437595d96507cf6599cf5a7fd6c4
   branch: master
   specs:
     plan_executor (1.0.0)

--- a/app/assets/javascripts/views/component/conformance.coffee
+++ b/app/assets/javascripts/views/component/conformance.coffee
@@ -21,6 +21,7 @@ class Crucible.Conformance
       .success ((data) =>
         @updateConformance(data)
         @removeConformanceSpinner()
+        @element.trigger('conformanceInitialized') if data.conformance.updated
       )
       .error ((data) =>
         @removeConformanceSpinner()
@@ -55,7 +56,7 @@ class Crucible.Conformance
       auth = @conformance.rest[0].security.extension[0].extension.find((elem, ind, arr)->
         elem.url == url
       )
-      auth.value.value
+      auth.value.value if auth
 
   authType: =>
       if @conformance.rest[0].security && @conformance.rest[0].security.extension

--- a/app/assets/javascripts/views/component/test-run-report.coffee
+++ b/app/assets/javascripts/views/component/test-run-report.coffee
@@ -39,7 +39,7 @@ class Crucible.TestRunReport
       continue if failure.hidden
       total += 1
       messageMap[failure.message] ||= {message: failure.message, failures: []}
-      failure.suite = @suitesById[failure.test_id.$oid] if @suitesById?
+      failure.suite = @suitesById[failure.test_id] if @suitesById?
       messageMap[failure.message].failures.push failure
     failuresByMessage = _.sortBy(_.values(messageMap), (v) -> -v.failures.length)
     @failuresReportElement.html(HandlebarsTemplates[@templates.failures]({failuresByMessage: failuresByMessage, total: total}))

--- a/app/assets/javascripts/views/templates/servers/suite_result.hbs
+++ b/app/assets/javascripts/views/templates/servers/suite_result.hbs
@@ -17,7 +17,7 @@
         <table class="table table-hover report-table nav nav-stacked">
           <tbody>
             {{#each result.tests as |test|}}
-            <tr class="{{#if @first}}active {{/if}}suite-handle" data-key="{{test.key}}">
+            <tr class="{{#if @first}}active {{/if}}suite-handle" data-key="{{test.key}}" id="{{test.id}}">
               <td>
                 <span><i class="{{test-status test.status}}"></i></span>
               </td>

--- a/app/assets/javascripts/views/templates/servers/suite_select.hbs
+++ b/app/assets/javascripts/views/templates/servers/suite_select.hbs
@@ -16,7 +16,7 @@
         <table class="table report-table nav nav-stacked">
           <tbody>
             {{#each suite.methods as |method|}}
-              <tr class="{{#if @first}}active {{/if}}suite-handle" data-key="{{method.key}}">
+              <tr class="{{#if @first}}active {{/if}}suite-handle" data-key="{{method.key}}" id="{{method.id}}">
                 <td>
                   {{method.key}}
                 </td>

--- a/app/controllers/test_runs_controller.rb
+++ b/app/controllers/test_runs_controller.rb
@@ -8,7 +8,7 @@ class TestRunsController < ApplicationController
   end
 
   def create
-    run = TestRun.new({server_id: params[:server_id], date: Time.now})
+    run = TestRun.new({server_id: params[:server_id], date: Time.now, supported_only: (params[:supported_only]=='true')})
     tests = params[:test_ids].map {|i| Test.find(i)}
 
     run.add_tests(tests)

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -1,5 +1,6 @@
 class Test
   include Mongoid::Document
+  field :id, type: String
   field :name
   field :title
   field :resource_class, type: String, default: ''
@@ -10,6 +11,8 @@ class Test
   field :links
   field :multiserver, type: Boolean, default: false
   field :methods, type: Array
+  field :supported, type: Boolean, default: false
+  field :load_version, type: Integer, default: 0
 
   def serializable_hash(options = nil)
     hash = super(options)

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -82,6 +82,7 @@
 
                     <%= render partial: "components/server_summary", locals: {server: @server, noHeader: true}%>
                     <div class="button-holder">
+                      <span class="tag collapse in filter-by-supported">supported only <a href="#"><i class="fa fa-times"></i></a></span>
                       <span class="tag collapse filter-by-executed">executed only <a href="#"><i class="fa fa-times"></i></a></span>
                       <select class="past-test-runs-selector form-control"></select>
                       <button class="btn execute">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     get 'oauth_params', defaults: { format: :json }
     get 'aggregate_run', defaults: { format: :json }
     get 'past_runs', defaults: { format: :json }
+    get 'supported_tests', defaults: { format: :json }
     post 'oauth_params'
   end
 

--- a/lib/tasks/crucible.rake
+++ b/lib/tasks/crucible.rake
@@ -36,7 +36,7 @@ namespace :crucible do
   desc "schedule a job for all servers"
   task :nightly_run => [:environment] do
 
-    Server.all.each_with_index do |s, i|
+    Server.all.sort {|l,r| (r.percent_passing||0) <=> (l.percent_passing||0)}.each_with_index do |s, i|
       puts "\tStarting Server #{i+1} of #{Server.all.length}"
 
       test_run = TestRun.new({server: s, date: Time.now})

--- a/spec/javascripts/magic_lamp.rb
+++ b/spec/javascripts/magic_lamp.rb
@@ -1,6 +1,7 @@
 MagicLamp.define(controller: ServersController) do
   fixture do # servers/show
     @server = Server.new(url: 'www.example.com')
+    @server.save!
     @tests = Test.all.sort {|l,r| l.name <=> r.name}
     render :show
   end  

--- a/test/fixtures/json/conformance/partial_conformance.json
+++ b/test/fixtures/json/conformance/partial_conformance.json
@@ -1,0 +1,429 @@
+{
+  "url": "https://open-ic.epic.com/FHIR/api/FHIR/DSTU2/Conformance/TxQrMBpZxIgGY6ic81DnDOQB",
+  "version": "TxQrMBpZxIgGY6ic81DnDOQB",
+  "experimental": true,
+  "date": "2015-11-12T13:41:12",
+  "copyright": "Copyright Epic 1979-2015",
+  "software": {
+    "name": "Epic 2015",
+    "version": "8.2.2"
+  },
+  "fhirVersion": "1.0.1",
+  "rest": [
+    {
+      "mode": "server",
+      "security": {
+        "cors": true,
+        "extension": [
+          {
+            "_id": {
+              "$oid": "5644971f4d4d32695f040000"
+            },
+            "xmlId": null,
+            "url": "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris",
+            "extension": [
+              {
+                "_id": {
+                  "$oid": "5644971f4d4d32695f050000"
+                },
+                "xmlId": null,
+                "url": "authorize",
+                "value": "#<FHIR::AnyType:0x0000010f0a18a0>"
+              },
+              {
+                "_id": {
+                  "$oid": "5644971f4d4d32695f060000"
+                },
+                "xmlId": null,
+                "url": "token",
+                "value": "#<FHIR::AnyType:0x0000010f0a15f8>"
+              }
+            ]
+          }
+        ]
+      },
+      "resource": [
+        {
+          "type": "AllergyIntolerance",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "_id",
+              "type": "token"
+            },
+            {
+              "name": "patient",
+              "type": "reference"
+            },
+            {
+              "name": "subject",
+              "type": "reference"
+            }
+          ]
+        },
+        {
+          "type": "Appointment",
+          "interaction": [
+            {
+              "code": "create"
+            }
+          ]
+        },
+        {
+          "type": "Condition",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "patient",
+              "type": "reference"
+            },
+            {
+              "name": "_id",
+              "type": "token"
+            },
+            {
+              "name": "clinicalStatus",
+              "type": "token"
+            },
+            {
+              "name": "category",
+              "type": "token"
+            },
+            {
+              "name": "subject",
+              "type": "reference"
+            }
+          ]
+        },
+        {
+          "type": "Conformance",
+          "interaction": [
+            {
+              "code": "metadata"
+            },
+            {
+              "code": "read"
+            }
+          ]
+        },
+        {
+          "type": "DiagnosticReport",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "subject",
+              "type": "reference"
+            },
+            {
+              "name": "serviceCategory",
+              "type": "token"
+            },
+            {
+              "name": "patient",
+              "type": "reference"
+            }
+          ]
+        },
+        {
+          "type": "FamilyMemberHistory",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            },
+            {
+              "code": "write"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "patient",
+              "type": "reference"
+            },
+            {
+              "name": "subject",
+              "type": "reference"
+            }
+          ]
+        },
+        {
+          "type": "Medication",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "_id",
+              "type": "token"
+            }
+          ]
+        },
+        {
+          "type": "MedicationOrder",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "patient",
+              "type": "reference"
+            },
+            {
+              "name": "status",
+              "type": "token"
+            },
+            {
+              "name": "_id",
+              "type": "token"
+            },
+            {
+              "name": "subject",
+              "type": "reference"
+            }
+          ]
+        },
+        {
+          "type": "Observation",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "code",
+              "type": "token"
+            },
+            {
+              "name": "_id",
+              "type": "token"
+            },
+            {
+              "name": "date",
+              "type": "date"
+            },
+            {
+              "name": "patient",
+              "type": "reference"
+            },
+            {
+              "name": "subject",
+              "type": "reference"
+            }
+          ]
+        },
+        {
+          "type": "Patient",
+          "interaction": [
+            {
+              "code": "create"
+            },
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            },
+            {
+              "code": "update"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "_id",
+              "type": "token"
+            },
+            {
+              "name": "identifier",
+              "type": "token"
+            },
+            {
+              "name": "family",
+              "type": "string"
+            },
+            {
+              "name": "given",
+              "type": "string"
+            },
+            {
+              "name": "birthdate",
+              "type": "date"
+            },
+            {
+              "name": "address",
+              "type": "string"
+            },
+            {
+              "name": "gender",
+              "type": "token"
+            },
+            {
+              "name": "telecom",
+              "type": "token"
+            },
+            {
+              "name": "deathdate",
+              "type": "date"
+            },
+            {
+              "name": "active",
+              "type": "token"
+            },
+            {
+              "name": "deceased",
+              "type": "token"
+            }
+          ]
+        },
+        {
+          "type": "Practitioner",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "_id",
+              "type": "token"
+            },
+            {
+              "name": "address",
+              "type": "string"
+            },
+            {
+              "name": "family",
+              "type": "string"
+            },
+            {
+              "name": "gender",
+              "type": "token"
+            },
+            {
+              "name": "given",
+              "type": "string"
+            },
+            {
+              "name": "identifier",
+              "type": "token"
+            },
+            {
+              "name": "name",
+              "type": "string"
+            },
+            {
+              "name": "organization",
+              "type": "reference"
+            },
+            {
+              "name": "phonetic",
+              "type": "string"
+            },
+            {
+              "name": "telecom",
+              "type": "token"
+            },
+            {
+              "name": "role",
+              "type": "token"
+            },
+            {
+              "name": "specialty",
+              "type": "token"
+            }
+          ]
+        },
+        {
+          "type": "Schedule",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "actor",
+              "type": "reference"
+            },
+            {
+              "name": "date",
+              "type": "date"
+            },
+            {
+              "name": "type",
+              "type": "token"
+            }
+          ]
+        },
+        {
+          "type": "Slot",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "search-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "identifier",
+              "type": "token"
+            },
+            {
+              "name": "schedule",
+              "type": "reference"
+            },
+            {
+              "name": "start",
+              "type": "date"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "resourceType": "Conformance"
+}


### PR DESCRIPTION
this also includes changes to the reponse format of tests from plan executor to simplify the format
it includes changes to the test loading to allow forcing tests to reload
it changes test ids from the mongo id to the id provided by plan exectuor
