### PR TITLE
Updated the Auth component Coffeescript so a selector is accurate

### DIFF
--- a/app/assets/javascripts/views/component/authorization.coffee
+++ b/app/assets/javascripts/views/component/authorization.coffee
@@ -32,7 +32,7 @@ class Crucible.Authorization
           $(this).val()
         ).get().join(" ")
         $("#scope").val(scope)
-        $("[name='scope_vars[]'").each(() ->
+        $("[name='scope_vars[]']").each(() ->
           $(this).attr('checked', false)
         )
         event.target.submit()


### PR DESCRIPTION
There was a jQuery selector that was missing an end bracket. For some reason, this was being masked by Chrome, but was breaking the selector in Firefox. This adds in the missing bracket so the selector works in all browsers again.
