### PR TITLE
Sort past test runs by date in controller

### DIFF
--- a/app/assets/javascripts/views/component/test-executor.coffee
+++ b/app/assets/javascripts/views/component/test-executor.coffee
@@ -92,7 +92,7 @@ class Crucible.TestExecutor
       if elementToAdd
         selector.append("<option value='#{elementToAdd.value}' disabled='#{elementToAdd.disabled}''>#{elementToAdd.text}</option>")
       selector.show()
-      $(data['past_runs'].reverse()).each (i, test_run) =>
+      $(data['past_runs']).each (i, test_run) =>
         selection = "<option value='#{test_run.id}'> #{moment(test_run.date).fromNow()} </option>"
         selector.append(selection)
     )

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -98,7 +98,7 @@ class ServersController < ApplicationController
 
   def past_runs
     server = Server.find(params[:server_id])
-    past_runs = TestRun.where(server: server, status: 'finished')
+    past_runs = TestRun.where(server: server, status: 'finished').order_by(:date => 'desc')
     render json: {past_runs: past_runs}
   end
 


### PR DESCRIPTION
Problem: past test runs weren't properly sorted in the selector on the server show page. 

Solution: sort them in the controller by execution date before we hand them back to the client.
