### PR TITLE
Updated the confidential auth flow to not pass in the client ID

### DIFF
--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -50,7 +50,13 @@ class ServersController < ApplicationController
       client = OAuth2::Client.new(server.client_id, server.client_secret, options)
       if (!server.client_secret.empty?)
         auth_pw = Base64.strict_encode64("#{server.client_id}:#{server.client_secret}")
-        token = client.auth_code.get_token(params[:code], :redirect_uri => "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}/redirect", :headers=> {'Authorization' => "Basic #{auth_pw}"})
+        token_params = {
+          redirect_uri: "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}/redirect",
+          code: params[:code],
+          grant_type: "authorization_code",
+        }
+        response = client.request(:post, server.token_url, {:params => token_params, :headers => {'Authorization' => "Basic #{auth_pw}"}})
+        token = OAuth2::AccessToken.from_hash(client, JSON.parse(response.body))
       else
         token = client.auth_code.get_token(params[:code], :redirect_uri => "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}/redirect")
       end


### PR DESCRIPTION
This is in accordance with [SMART Oauth2 guidelines](http://docs.smarthealthit.org/authorization/), which state that the client ID shouldn't be a POST parameter if the app flow is confidential. This was breaking InterSystems authorization. Update required a rewrite to manually make a POST request through the OAuth2 gem, rather than using the `auth_code` `get_token` method.
