### PR TITLE
Added a patient ID parameter to the OAuth2 auth form

### DIFF
--- a/app/assets/javascripts/views/component/authorization.coffee
+++ b/app/assets/javascripts/views/component/authorization.coffee
@@ -24,7 +24,8 @@ class Crucible.Authorization
           client_secret: $('#client_secret').val(),
           authorize_url: $('#conformance-data').children().data('authorize-url'),
           token_url: $('#conformance-data').children().data('token-url'),
-          state: $('#state').val()
+          state: $('#state').val(),
+          launch_param: $('#launch_param').val()
       },
       'JSON'
       ).success((data)->

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -65,6 +65,11 @@ class ServersController < ApplicationController
         redirect_to server_path(server)
         return
       end
+
+      if !token.params["patient"] && server.launch_param
+        token.params["patient"] = server.launch_param
+      end
+
       server.oauth_token_opts = token.to_hash
       server.save!
       flash.notice = "Server successfully authorized"
@@ -124,11 +129,12 @@ class ServersController < ApplicationController
   def oauth_params
     server = Server.find(params[:server_id])
     if server
-      server.client_id = params[:client_id]
-      server.client_secret = params[:client_secret] unless server.client_secret && params[:client_secret] === '*' * server.client_secret.length
+      server.client_id = params[:client_id].strip
+      server.client_secret = params[:client_secret].strip unless server.client_secret && params[:client_secret] === '*' * server.client_secret.length
       server.state = params[:state]
       server.authorize_url = params[:authorize_url]
       server.token_url = params[:token_url]
+      server.launch_param = params[:launch_param].strip if params[:launch_param]
       server.save
       render json: { success: true }
     end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -14,6 +14,7 @@ class Server
   field :state, type: String
   field :client_id, type: String
   field :client_secret, type: String
+  field :launch_param, type: String
   field :authorize_url, type: String
   field :token_url, type: String
   field :oauth_token_opts, type: Hash

--- a/app/views/servers/_authorization.html.erb
+++ b/app/views/servers/_authorization.html.erb
@@ -15,7 +15,11 @@
         <label for="client_secret">Client Secret</label>
         <input type="password" id="client_secret" name="client_secret" class="form-control authorize_form_element"  <% if @server.tags.include?('argonaut') %> value="<%= ("*" * @server.client_secret.length) if @server.client_secret %>" <% end %> />
       </div>
-      
+      <div class="form-group">
+        <label for="launch_param">Patient ID (optional)</label>
+        <input type="text" id="launch_param" name="launch_param" class="form-control authorize_form_element" <% if @server.tags.include?('argonaut')%>value="<%= @server.launch_param %>"<% end %> />
+      </div>
+
       <div class="form-group scope-types">
         <table>
           <thead>


### PR DESCRIPTION
This will get passed into the client when tests are run if no patient param is passed back from the auth flow. This parameter is not the same as the EHR launch sequence, because that requires an opaque launch value which is passed from the EHR to the app (Crucible).
