### PR TITLE
Add test run summary and failure only filter

### DIFF
--- a/app/assets/javascripts/views/handlebars_helpers.coffee
+++ b/app/assets/javascripts/views/handlebars_helpers.coffee
@@ -46,3 +46,7 @@ Handlebars.registerHelper('supported-status', (resource, operation) ->
   else
     return "test-empty"
 )
+
+Handlebars.registerHelper('percentage', (numerator, denominator) ->
+  return "#{Math.round((numerator/denominator) * 100)}%"
+)

--- a/app/assets/javascripts/views/templates/servers/partials/test_run_summary.hbs
+++ b/app/assets/javascripts/views/templates/servers/partials/test_run_summary.hbs
@@ -1,0 +1,10 @@
+<div class="well well-sm testrun-summary">
+  <h3>Test Run Summary</h3>
+
+  <div>
+    Suites: {{suites.pass}} of {{suites.total}} passed ({{percentage suites.pass suites.total}})
+  </div>
+  <div>
+    Tests: {{tests.pass}} of {{tests.total}} passed ({{percentage tests.pass tests.total}})
+  </div>
+</div>

--- a/app/assets/stylesheets/_tests.scss
+++ b/app/assets/stylesheets/_tests.scss
@@ -58,7 +58,7 @@
 
 .tab-content-holder .test-results {
   .button-holder{
-    margin-bottom: 20px;
+    margin-bottom: 10px;
     padding-bottom: 10px;
     padding-top: 10px;
     /*border-bottom: 1px solid $structure;*/
@@ -83,6 +83,12 @@
   }
   .close-change-test-run{
     font-size: 14px;
+  }
+  .testrun-summary{
+    text-align: left;
+  }
+  h3{
+    margin-top: 10px;
   }
 }
 

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -81,14 +81,16 @@
                             <option selected="true" disabled="true">Select a filter...</option>
                             <option value="supported">supported only</option>
                             <option value="executed">executed only</option>
+                            <option value="failures">failures only</option>
                           </select>
                         </span>
                         <a><i class="fa fa-close"></i></a>
                       </div>
                     </div>
                     <div class="button-holder">
-                      <span class="tag collapse in filter-by-supported">supported only <a href="#"><i class="fa fa-times"></i></a></span>
-                      <span class="tag collapse filter-by-executed" aria-expanded="false">executed only <a href="#"><i class="fa fa-times"></i></a></span>
+                      <span class="tag filter-by-supported">supported only <a href="#"><i class="fa fa-times"></i></a></span>
+                      <span class="tag filter-by-executed">executed only <a href="#"><i class="fa fa-times"></i></a></span>
+                      <span class="tag filter-by-failures">failures only <a href="#"><i class="fa fa-times"></i></a></span>
                     </div>
                   </div>
                 </div>
@@ -125,6 +127,7 @@
                       </div>
                     </div>
                     <div class="warning-message alert alert-danger" role="alert"></div>
+                    <div class="testrun-summary" style="display:none">summary</div>
                     <div class="test-suites">
                     </div>
                   </div>


### PR DESCRIPTION
Normally I would have made this 2 PRs, but the original implementation had the failure-only filter within the test run summary.  I didn't realize how I decoupled into 2 features based on Jay's feedback until just now, and it will be some work to cherry pick out the changes and retest.  So I'm leaving them together in 1 PR for now.

One outstanding issue is that we use "Test Run Summary" in 2 spots to mean different things.  I personally think we should change the one in the main tab to "Server Test Summary" or something.

Try out choosing previously run test runs, doing a new test run, and the failure filter which is now in the filter dropdown to see if it works & looks the way you would expect.  Feedback welcome, I'm happy to update this if you have ideas for improvements.

![screen shot 2016-01-22 at 5 16 47 pm](https://cloud.githubusercontent.com/assets/412901/12525307/61c42454-c131-11e5-8fd2-14658bd44967.png)

Note in this example that "failures only" filter is active, so only 2 of the 3 suite results are shown.
