### PR TITLE
Server tags

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,6 +24,7 @@
 //= require jquery-validation/dist/jquery.validate.js
 //= require vkbeautify/vkbeautify.js
 //= require clipboard/dist/clipboard.js
+//= require bootstrap-tagsinput/dist/bootstrap-tagsinput.js
 
 //= require crucible
 //= require_tree ./views/templates

--- a/app/assets/javascripts/views/component/server-details.coffee
+++ b/app/assets/javascripts/views/component/server-details.coffee
@@ -63,4 +63,3 @@ class Crucible.ServerDetails
     for tag in tags
       tagElement = $("<span>").addClass("tag").text(tag)
       labelContainer.append(tagElement)
-      tagElement.after(" ")

--- a/app/assets/javascripts/views/component/server-details.coffee
+++ b/app/assets/javascripts/views/component/server-details.coffee
@@ -9,6 +9,7 @@ class Crucible.ServerDetails
     return unless @element.length
     @serverId = @element.data('server-id')
     @registerHandlers()
+    @renderTags()
 
   registerHandlers: =>
     @element.find('.edit-server-name-icon').click(@toggleEditDialogue)
@@ -29,16 +30,18 @@ class Crucible.ServerDetails
         loadingIndicator = @element.find('#server_update_form .submit-server-name .fa-spinner')
         newName = @element.find('#edit-server-name-dialogue').val()
         newURL = @element.find('#edit-server-url-dialogue').val()
+        newTags = @element.find('#edit-server-tags-dialogue').val()
         loadingIndicator.toggleClass('hide')
         $.ajax({
           type: 'PUT',
           url: "/servers/#{@serverId}",
-          data: {server: {name: newName, url: newURL}},
+          data: {server: {name: newName, url: newURL, tags: newTags}},
           success: ((data) =>
             @element.find('.server-name-label').html(newName)
             @element.find('.server-name-panel').attr('title', newName).tooltip('fixTitle')
             @element.find('.server-url-label').html(newURL)
             @element.find('.server-url-panel').attr('title', newURL).tooltip('fixTitle')
+            @renderTags()
 
             @toggleEditDialogue()
           )
@@ -50,3 +53,14 @@ class Crucible.ServerDetails
         });
         false
     )
+
+  renderTags: =>
+    tags = @element.find('#edit-server-tags-dialogue').val().split(',')
+    tags = tags.map (element) -> element.trim()
+    tags = tags.filter (element) -> element.length > 0
+    labelContainer = @element.find(".server-tags-label")
+    labelContainer.empty()
+    for tag in tags
+      tagElement = $("<span>").addClass("tag").text(tag)
+      labelContainer.append(tagElement)
+      tagElement.after(" ")

--- a/app/assets/javascripts/views/component/server-details.coffee
+++ b/app/assets/javascripts/views/component/server-details.coffee
@@ -83,5 +83,5 @@ class Crucible.ServerDetails
       labelContainer.append(tagElement)
 
   identifyProtectedTags: =>
-    tags = @element.find('#edit-server-tags-dialogue').val().split(',')
-    tags.filter (n) => @protectedTags.indexOf(n.toLowerCase()) != -1
+    tags = @element.find('#edit-server-tags-dialogue').val().split(',').map (e) -> e.toLowerCase()
+    tags = tags.filter (n) => @protectedTags.indexOf(n) != -1

--- a/app/assets/stylesheets/_server.scss
+++ b/app/assets/stylesheets/_server.scss
@@ -73,6 +73,7 @@
   .bootstrap-tagsinput {
     border: 1px solid #ccc;
     padding: 2px 0 0 2px;
+    clear: both; // If the URL has an error
     input {
       font-size: 12px;
       border: 0;

--- a/app/assets/stylesheets/_server.scss
+++ b/app/assets/stylesheets/_server.scss
@@ -46,6 +46,23 @@
       margin-left: 10px;
     }
   }
+
+  .tag {
+    display: inline-block;
+    background-color: $brand-accent;
+    border: 3px solid $brand-accent;
+    color: $brand-tertiary;
+    border-radius: 2px;
+    font-size: 12px;
+    font-weight: 100;
+    padding: 3px;
+    margin-bottom: 5px;
+    line-height: 14px;
+    a {
+      color: $brand-tertiary;
+      cursor: pointer
+    }
+  }
 }
 
 .server-test-details{
@@ -186,9 +203,14 @@
     width: 100%;
     margin-bottom: 5px;
   };
-  #edit-server-url-dialogue{width: 100%;};
+  #edit-server-url-dialogue{
+    width: 100%;
+    margin-bottom: 5px;
+  };
+  #edit-server-tags-dialogue{width: 100%;};
   button{width: 100px; display: inline}
 }
+
 
 
 // ------------------------- TEST RUN SUMMARY TAB ----------------------------------- // 

--- a/app/assets/stylesheets/_server.scss
+++ b/app/assets/stylesheets/_server.scss
@@ -25,6 +25,10 @@
     color: $brand-accent;
   }
 
+  input {
+    padding-left: 5px;
+  }
+
   .authorize-icon {
     margin-right: 15px;
     font-size: 45px;
@@ -56,16 +60,39 @@
     font-size: 12px;
     font-weight: 100;
     padding: 3px;
+    padding-top: 6px;
     margin-bottom: 5px;
-    line-height: 14px;
+    margin-right: 5px;
+    line-height: 8px;
     a {
       color: $brand-tertiary;
       cursor: pointer
     }
   }
+
+  .bootstrap-tagsinput {
+    border: 1px solid #ccc;
+    padding: 2px 0 0 2px;
+    input {
+      font-size: 12px;
+      border: 0;
+      outline-width: 0px;
+    }
+
+    span [data-role="remove"] {
+      margin-left: 8px;
+      cursor: pointer;
+      &:after{
+        content: "x";
+        padding: 0 2px;
+      }
+    }
+    
+  }
 }
 
 .server-test-details{
+  text-align: left;
   margin-bottom: 30px;
 }
 

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -24,6 +24,7 @@ class ServersController < ApplicationController
 
   def update
     server = Server.find(params[:id])
+    params[:server][:tags] = params[:server][:tags].split(",").map(&:strip)
     server.update(server_params)
     server.name_guessed = false if server_params[:name]
     server.guess_name # will only change if blank
@@ -143,6 +144,6 @@ class ServersController < ApplicationController
   private
 
   def server_params
-    params.require(:server).permit(:url, :name)
+    params.require(:server).permit(:url, :name, tags: [])
   end
 end

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -36,9 +36,10 @@
               <div class="edit-panel row hide editToggle">
                 <form id="server_update_form">
                   <div class="col-md-6">
-                    <input id="edit-server-name-dialogue" name="name" value='<%= @server.name %>'>
-                    <input id="edit-server-url-dialogue" name="url" value='<%= @server.url %>'>
+                    <input id="edit-server-name-dialogue" name="name" value='<%= @server.name %>' placeholder='Server Name'>
+                    <input id="edit-server-url-dialogue" name="url" value='<%= @server.url %>' placeholder='Server URL'>
                     <input id="edit-server-tags-dialogue" name="tags" value='<%= @server.tags.join(',') %>' placeholder="Add Tag" data-role="tagsinput">
+                    <label id="edit-server-tags-dialogue-error" class="error" for="edit-server-tags-dialogue" style="display:none"></label>
                   </div>
                   <div class="col-md-3">
                     <button class="btn secondary submit-server-name"><i class="fa fa-lg fa-fw fa-spinner fa-pulse hide"> </i>Save</button>

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -21,12 +21,15 @@
               <div class="authorize-icon pull-left">
                 <a data-toggle="modal" data-target="#authorize-modal" class="authorization-handle authorization_handle hidden" href="#"><i class="fa fa-lock"></i></a>
               </div>
-              <div class=" server-url-name pull-left">
+              <div class="server-url-name pull-left">
                 <div class="server-name-panel emphasize editToggle" data-toggle="tooltip" data-placement="bottom" title="<%= @server.name %>">
                   <div class="server-name-label"><%= @server.name %></div>
                 </div>
                 <div class="server-url-panel editToggle" data-toggle="tooltip" data-placement="bottom" title="<%= @server.url %>">
                   <a target="_blank" class="server-url-label" href="<%= @server.url %>"><%= @server.url %></a>
+                </div>
+                <div class="server-tags-panel emphasize editToggle">
+                    <div class="server-tags-label"></div>
                 </div>
               </div>
               <a class="edit-server-name-icon editToggle pull-left"><i class="fa fa-pencil-square-o edit-server-name"></i></a>
@@ -35,6 +38,7 @@
                   <div class="col-md-6">
                     <input id="edit-server-name-dialogue" name="name" value='<%= @server.name %>'>
                     <input id="edit-server-url-dialogue" name="url" value='<%= @server.url %>'>
+                    <input id="edit-server-tags-dialogue" name="tags" value='<%= @server.tags.join(',') %>' placeholder="Server Tags">
                   </div>
                   <div class="col-md-3">
                     <button class="btn secondary submit-server-name"><i class="fa fa-lg fa-fw fa-spinner fa-pulse hide"> </i>Save</button>

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -38,7 +38,7 @@
                   <div class="col-md-6">
                     <input id="edit-server-name-dialogue" name="name" value='<%= @server.name %>'>
                     <input id="edit-server-url-dialogue" name="url" value='<%= @server.url %>'>
-                    <input id="edit-server-tags-dialogue" name="tags" value='<%= @server.tags.join(',') %>' placeholder="Server Tags">
+                    <input id="edit-server-tags-dialogue" name="tags" value='<%= @server.tags.join(',') %>' placeholder="Add Tag" data-role="tagsinput">
                   </div>
                   <div class="col-md-3">
                     <button class="btn secondary submit-server-name"><i class="fa fa-lg fa-fw fa-spinner fa-pulse hide"> </i>Save</button>

--- a/bower.json
+++ b/bower.json
@@ -18,5 +18,8 @@
     "vkbeautify": "a08344e94d3241d30ac21b1f1935f74d504be00e",
     "clipboard": "~1.5.5",
     "bootstrap-tagsinput": "~0.7.1"
+  },
+  "resolutions": {
+    "jquery": ">= 1.9.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
     "highlightjs": "8.8.0",
     "jquery-ujs": "~1.1.0",
     "vkbeautify": "a08344e94d3241d30ac21b1f1935f74d504be00e",
-    "clipboard": "~1.5.5"
+    "clipboard": "~1.5.5",
+    "bootstrap-tagsinput": "~0.7.1"
   }
 }


### PR DESCRIPTION
Server tags front end interface update.

DAF and Argonaut (case-insensitive) are protected tags, so if you try to delete one it will give you an error.  To trigger that error, add the daf/argonaut tag, save, then refresh the page, then try to delete.  It won't trigger if you just add it then try to delete it (without saving & refreshing) to give the user a chance to back out of it before they really decide to add it.

You must do a `bower install` because I added a 3rd party library to handle rendering the tag editing interface.  Let me know if it looks odd or is not intuitive.

The only potential issue I know of is that the behavior might not be exactly intuitive with regards to case-sensitivity.  It would be cleaner if I could just lower-case all tags when entered into the system (but I don't).

![screen shot 2016-01-25 at 4 30 28 pm](https://cloud.githubusercontent.com/assets/412901/12565148/14a07270-c381-11e5-9529-cc234e5f0ce3.png)
