### PR TITLE
add next/prev test runs

### DIFF
--- a/app/assets/javascripts/views/templates/servers/partials/test_run_summary.hbs
+++ b/app/assets/javascripts/views/templates/servers/partials/test_run_summary.hbs
@@ -4,7 +4,12 @@
   <div>
     Suites: {{suites.pass}} of {{suites.total}} passed ({{percentage suites.pass suites.total}})
   </div>
-  <div>
+  <div class="testrun-summary-tests">
     Tests: {{tests.pass}} of {{tests.total}} passed ({{percentage tests.pass tests.total}})
   </div>
+  <div class="testrun-summary-nav">
+    <span class="testrun-summary-previous"><i class="fa fa-angle-double-left"></i> Previous</span>
+    <span class="testrun-summary-next">Next <i class="fa fa-angle-double-right"></i></span>
+  </div>
+  <div class="clearfix"></div>
 </div>

--- a/app/assets/stylesheets/_tests.scss
+++ b/app/assets/stylesheets/_tests.scss
@@ -93,6 +93,19 @@
   h3{
     margin-top: 10px;
   }
+  .testrun-summary-tests{
+    float: left;
+  }
+  .testrun-summary-nav{
+    float: right;
+    font-size: .9em;
+
+    span {
+      margin-right: 10px;
+      cursor: pointer;
+      color: $brand-accent;
+    }
+  }
 }
 
 .test-results{


### PR DESCRIPTION
I often find myself having to search through previous test runs.  Right now, in order to do so, you have to click to open up the select box, choose the next one you want to look at, etc.  It is easy to forget which one you are on, so in practice cycling through all the test runs is too much of a pain to do.

I added next/prev test run buttons in the summary.  Might make more sense to put them up on top next to the date, but I figured I'd do this to start since there was plenty of room.

Note: there is a bug regarding these buttons when you just ran a test run.  But it is the result of another bug (that is already in pivotal).  I figured I'd commit this and then fix that other bug next, since that will fix this small issue too.

![screen shot 2016-02-12 at 4 04 30 pm](https://cloud.githubusercontent.com/assets/412901/13020406/3ab4aa96-d1a3-11e5-8d46-aba7a5f4103c.png)
