### PR TITLE
update authtype to return none if no match on extension url

### DIFF
--- a/app/assets/javascripts/views/component/conformance.coffee
+++ b/app/assets/javascripts/views/component/conformance.coffee
@@ -80,6 +80,7 @@ class Crucible.Conformance
       if @conformance.rest[0].security && @conformance.rest[0].security.extension
         switch @conformance.rest[0].security.extension[0].url
           when "http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris" then "OAuth2"
+          else "none"
       else
         "none"
 


### PR DESCRIPTION
"Healthconnex (open)" was showing a padlock when it isn't secure.  Tracked it down to the authType being returned as a blank string instead of "none", which then triggered the padlock to show up.  I checked on a couple of other secure servers and don't believe that this breaks anything, though there is always the chance that another server had the wrong extension url and our bug allowed it to show as secure even though technically it shouldn't.
