### PR TITLE
Remove non alphanumeric chars from names for search filter

### DIFF
--- a/app/assets/javascripts/views/component/test-executor.coffee
+++ b/app/assets/javascripts/views/component/test-executor.coffee
@@ -267,7 +267,7 @@ class Crucible.TestExecutor
       $("#cancel-modal").hide()
 
   searchBoxHandler: =>
-    @filter(search: @searchBox.val().toLowerCase().replace(/\s/g, ""))
+    @filter(search: @searchBox.val().toLowerCase().replace(/\W/g, ''))
 
   filterByExecutedHandler: =>
     @filter(executed: false)
@@ -307,7 +307,7 @@ class Crucible.TestExecutor
       suiteElement = $(suiteElement)
       suite = suiteElement.data('suite')
       childrenIds = suite.methods.map (m) -> m.id
-      suiteElement.hide() if @filters.search.length > 0 && (suite.name.toLowerCase()).indexOf(@filters.search) < 0
+      suiteElement.hide() if @filters.search.length > 0 && (suite.name.toLowerCase().replace(/\W/g,'')).indexOf(@filters.search) < 0
       suiteElement.hide() if @filters.executed && !suiteElement.hasClass("executed")
       suiteElement.hide() if @filters.starburstNode? && !(_.intersection(starburstTestIds, childrenIds).length > 0)
       suiteElement.hide() if @filters.supported && !(suite.supported)


### PR DESCRIPTION
The testscript names had dashes in them, causing search to not work.  I changed the regex to strip out non-alphanumeric characters (and not just spaces) so that it will ignore dashes (and spaces and underscores and anything like that).  I couldn't think of a valid reason why you would have non alphanumeric characters in a title (and would need to be paid attention to in search).
