### PR TITLE
Expose test categories defined in the plan executor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 
 GIT
   remote: https://github.com/fhir-crucible/plan_executor.git
-  revision: 670aed35c4ef0fdae2bf8097c5751b241a23acb2
+  revision: fbd500d93bb7f899e4d3dc4473bea92c5a50f8fe
   branch: master
   specs:
     plan_executor (1.0.0)

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -15,6 +15,7 @@ class Test
   field :load_version, type: Integer, default: 0
   field :tags, type: Array
   field :details, type: Hash
+  field :category, type: String
 
   def serializable_hash(options = nil)
     hash = super(options)

--- a/config/initializers/store_tests.rb
+++ b/config/initializers/store_tests.rb
@@ -1,5 +1,5 @@
 # date based version to force tests to reload on startup
-LOAD_VERSION=20160120
+LOAD_VERSION=20160222
 
 Test.any_of({:load_version.exists => false},{:load_version.lt => LOAD_VERSION}).delete
 
@@ -16,6 +16,7 @@ Crucible::Tests::Executor.list_all.each do |key,value|
     test.author = value["author"]
     test.description = value["description"]
     test.tags = value['tags']
+    test.category = value['category']
     test.details = value['details'] unless value['details'].blank?
 
     crucibleTest = executor.find_test(value['title'])


### PR DESCRIPTION
Requires PR to plan_executor first.  After merging this, be sure to update `Gemfile.lock`.
