### PR TITLE
Ui fixes

### DIFF
--- a/app/assets/javascripts/views/component/test-executor.coffee
+++ b/app/assets/javascripts/views/component/test-executor.coffee
@@ -165,6 +165,7 @@ class Crucible.TestExecutor
     @element.find('.suite-selectors').hide()
     @hideTestResultSummary()
     $('.selectDeselectAll').html(@html.deselectAllButton)
+    $('.expandCollapseAll').html(@html.expandAllButton)
     $('.test-result-loading').show()
     selector = @element.find('.past-test-runs-selector')
     @selectedTestRunId = selector.val()

--- a/app/assets/javascripts/views/component/test-executor.coffee
+++ b/app/assets/javascripts/views/component/test-executor.coffee
@@ -15,8 +15,8 @@ class Crucible.TestExecutor
     testRequestDetails: 'views/templates/servers/partials/test_request_details'
     testRunSummary: 'views/templates/servers/partials/test_run_summary'
   html:
-    selectAllButton: '<i class="fa fa-close"></i>'
-    deselectAllButton: '<i class="fa fa-check"></i>'
+    deselectAllButton: '<i class="fa fa-close"></i>'
+    selectAllButton: '<i class="fa fa-check"></i>'
     collapseAllButton: '<i class="fa fa-compress"></i>'
     expandAllButton: '<i class="fa fa-expand"></i>'
     spinner: '<span class="fa fa-lg fa-fw fa-spinner fa-pulse tests"></span>'
@@ -156,12 +156,15 @@ class Crucible.TestExecutor
     @element.find('.clear-past-run-data').hide()
     @renderSuites()
     @filter(executed: false)
+    $('.expandCollapseAll').html(@html.expandAllButton)
+    $('.selectDeselectAll').html(@html.selectAllButton)
 
   updateCurrentTestRun: =>
     @element.find('.test-suites').empty()
     @element.find('.execute').hide()
     @element.find('.suite-selectors').hide()
     @hideTestResultSummary()
+    $('.selectDeselectAll').html(@html.deselectAllButton)
     $('.test-result-loading').show()
     selector = @element.find('.past-test-runs-selector')
     @selectedTestRunId = selector.val()
@@ -209,18 +212,20 @@ class Crucible.TestExecutor
     @element.find('.add-filter-selector').toggle()
 
   selectDeselectAll: =>
-    suiteElements = @element.find('.test-run-result :visible :checkbox')
     button = $('.selectDeselectAll')
-    if !$(suiteElements).prop('checked')
-      $(suiteElements).prop('checked', true)
-      $(button).html(@html.selectAllButton)
-    else
-      $(suiteElements).prop('checked', false)
+    if button.html() == @html.selectAllButton
+      # open all categories first
+      @element.find('.suite-group-body').collapse('show')
+      $('.expandCollapseAll').html(@html.collapseAllButton)
+      @element.find('.test-run-result :visible :checkbox').prop('checked', true)
       $(button).html(@html.deselectAllButton)
+    else
+      @element.find('.test-run-result :checkbox').prop('checked', false)
+      $(button).html(@html.selectAllButton)
+
 
   expandCollapseAll: =>
     suiteGroupBodies = @element.find('.suite-group-body')
-    # suiteElements = @element.find('.test-run-result').filter(':visible').find('.panel-collapse')
     button = $('.expandCollapseAll')
     if !$(suiteGroupBodies).hasClass('in')
       $(suiteGroupBodies).collapse('show')
@@ -472,6 +477,7 @@ class Crucible.TestExecutor
     @element.find('.suite-selectors').show()
     @element.find('.cancel').hide()
     @element.find('.past-test-runs-selector').attr("disabled", false)
+    $('.selectDeselectAll').html(@html.deselectAllButton)
     run_date = @element.find('.past-test-runs-selector').children().eq(1).html()
     @element.find('.selected-run').empty().html(run_date)
     @element.find('.clear-past-run-data').show()

--- a/app/assets/javascripts/views/templates/dashboards/server_result_row.hbs
+++ b/app/assets/javascripts/views/templates/dashboards/server_result_row.hbs
@@ -1,12 +1,12 @@
 <div class="dash-elem">
   <div class="row dash-row">
-    <div class="col-md-4 server-name">
+    <div class="col-sm-4 server-name">
       <svg width="18" height="18">
         <circle cx="9" cy="9" r="9" class="{{suite.status}}"/>
       </svg>
       <a data-toggle="collapse" href="#dash-{{server._id.$oid}}-{{suite.id}}">{{server.name}}</a>
     </div>
-    <div class="col-md-4 results">
+    <div class="col-sm-4 results">
       <span> 
         {{#each result.tests as |testResult|}}
           <span class="results-rectangle" data-toggle="tooltip" data-placement="top" title="{{testResult.description}}">
@@ -17,15 +17,15 @@
         {{/each}}
       </span>
     </div>
-    <div class="col-md-2 last-updated">
+    <div class="col-sm-2 last-updated">
       {{lastUpdated}}
     </div>
-    <div class="col-md-2 execute">
+    <div class="col-sm-2 execute">
       <a class="update" href="/servers/{{server._id.$oid}}">Update <i class="fa fa-arrow-circle-right"></i></a>
     </div>
   </div>
   <div class="row collapse" id="dash-{{server._id.$oid}}-{{suite.id}}">
-    <div class="col-md-12 dash-details">
+    <div class="col-sm-12 dash-details">
       {{> suite_result_details suite=suite result=result}}
     </div>
   </div>

--- a/app/assets/javascripts/views/templates/servers/conformance.hbs
+++ b/app/assets/javascripts/views/templates/servers/conformance.hbs
@@ -1,13 +1,13 @@
-<div class="col-md-12 tab-content-holder conformance" data-authorize-url="{{authorizeUrl}}" data-token-url="{{tokenUrl}}" data-auth-type="{{authType}}">
+<div class="col-sm-12 tab-content-holder conformance" data-authorize-url="{{authorizeUrl}}" data-token-url="{{tokenUrl}}" data-auth-type="{{authType}}">
   <!-- METADATA CONTAINER -->
   <div class="row screen-changer">
-    <div class="col-md-12">
+    <div class="col-sm-12">
       <span class="resources-changer active"><a>Conformance Resource Support</a></span>
       <span class="metadata-changer"><a>Conformance Metadata</a></span>
     </div>
   </div>
   <div class="row conformance metadata conformance-metadata hide">
-    <div class="metadata-selector col-md-3">
+    <div class="metadata-selector col-sm-3">
       <ul class="nav nav-pills nav-stacked metadata">
         <li class="active"><a data-toggle="tab" href="#conformance_metadata">Conformance Metadata</a></li>
         <li><a data-toggle="tab" href="#rest-metadata">REST Metadata</a></li>
@@ -17,7 +17,7 @@
     </div>
 
     <!-- METADATA EXPAND CONTAINER -->
-    <div class="metadata-expand-container col-md-9 tab-content">
+    <div class="metadata-expand-container col-sm-9 tab-content">
 
       <!-- CONFORMANCE METADATA  -->
       <div id="conformance_metadata" class="tab-pane active">
@@ -35,10 +35,10 @@
           {{> conformance_metadata title="FHIR VERSION" value=conformance.fhirVersion}}
           {{> conformance_metadata title="ACCEPT UNKNOWN" value=conformance.acceptUnknown boolean=true}}
           <div class="row">
-            <div class="col-md-4">
+            <div class="col-sm-4">
               <div><label>FORMATS SUPPORTED:</label></div>
             </div>
-            <div class="col-md-8">
+            <div class="col-sm-8">
               <div>{{#each conformance.format as |f|}}{{f}} {{/each}}</div>
             </div>
           </div>
@@ -86,7 +86,7 @@
     <!-- RESOURCE CHART -->
     <div class="row conformance">
       <div id="resource-chart" class="table-responsive">
-        <table class="col-md-12 table table-mega-striped table-condensed">
+        <table class="col-sm-12 table table-mega-striped table-condensed">
           <thead>
             <tr>
               <th>Resource Type</th>

--- a/app/assets/javascripts/views/templates/servers/conformance_metadata.hbs
+++ b/app/assets/javascripts/views/templates/servers/conformance_metadata.hbs
@@ -1,9 +1,9 @@
 <div class="row">
-  <div class="col-md-4">
+  <div class="col-sm-4">
     <div><label>{{title}}:</label></div>
   </div>
 
-  <div class="col-md-4 word-wrap">
+  <div class="col-sm-4 word-wrap">
     {{#if boolean}}
       {{#if value}}
         Yes
@@ -20,7 +20,7 @@
   </div>
 
   {{#if isMultiple}}
-    <div class="col-md-4 word-wrap">
+    <div class="col-sm-4 word-wrap">
       {{#if boolean}}
         {{#if value2}}
           Yes

--- a/app/assets/javascripts/views/templates/servers/failures_report.hbs
+++ b/app/assets/javascripts/views/templates/servers/failures_report.hbs
@@ -9,7 +9,7 @@
     </div>
   </div>
   <div class="failure-messages row">
-    <div class="col-md-12">
+    <div class="col-sm-12">
       {{#each failuresByMessage as |failureGroup|}}
         <div class="test-compliance-fail">
           <div class="failures-nav">
@@ -33,63 +33,63 @@
                     </div>
                     <div class="row test-stats">
                       {{#if failure.suite}}
-                        <div class="col-md-3 test-suite">
+                        <div class="col-sm-3 test-suite">
                           Suite
                         </div>
-                        <div class="col-md-9 test-stats-suite">
+                        <div class="col-sm-9 test-stats-suite">
                           {{title-case failure.suite.name}}
                         </div>
                       {{/if}}
                       {{#if failure.status}}
-                        <div class="col-md-3 test-stats-label">
+                        <div class="col-sm-3 test-stats-label">
                           Status
                         </div>
-                        <div class="col-md-9 test-stats-status">
+                        <div class="col-sm-9 test-stats-status">
                           {{failure.status}}
                         </div>
                       {{/if}}
                       {{#if failure.requires}}
-                        <div class="col-md-3 test-stats-label">
+                        <div class="col-sm-3 test-stats-label">
                           Requires
                         </div>
-                        <div class="col-md-9 test-stats-validates">
+                        <div class="col-sm-9 test-stats-validates">
                           {{#each failure.requires as |requirement|}}
                             <div>{{requirement.resource}}: {{#each requirement.methods as |method|}}{{method}}{{#unless @last}},{{/unless}}{{/each}}</div>
                           {{/each}}
                         </div>
                       {{/if}}
                       {{#if failure.validates}}
-                        <div class="col-md-3 test-stats-label">
+                        <div class="col-sm-3 test-stats-label">
                           Validates
                         </div>
-                        <div class="col-md-9 test-stats-validates">
+                        <div class="col-sm-9 test-stats-validates">
                           {{#each failure.validates as |validation|}}
                             {{> validation validation=validation}}
                           {{/each}}
                         </div>
                       {{/if}}
                       {{#if failure.links}}
-                        <div class="col-md-3 test-stats-label">
+                        <div class="col-sm-3 test-stats-label">
                           Links
                         </div>
-                        <div class="col-md-9 test-stats-links">
+                        <div class="col-sm-9 test-stats-links">
                           {{#each failure.links as |link|}}
                             <div><a target="_blank" href="{{link}}">Related FHIR Spec Location</a></div>
                           {{/each}}
                         </div>
                       {{/if}}
                       {{#if failure.data}}
-                        <div class="col-md-3 test-stats-label">
+                        <div class="col-sm-3 test-stats-label">
                           Data
                         </div>
-                        <div class="col-md-6 test-stats-data">
+                        <div class="col-sm-6 test-stats-data">
                           <div>
                             <a href="#" class="data-link" data-toggle="modal" data-target="#data-modal" data-content="">response data</a>
                             <div class="hidden data-content"><pre><code>{{failure.data}}</code></pre></div>
                           </div>
                         </div>
                       {{/if}}
-                        <div class="col-md-3">
+                        <div class="col-sm-3">
                           <!-- button -->
                         </div>
                     </div>

--- a/app/assets/javascripts/views/templates/servers/partials/suite_result_details.hbs
+++ b/app/assets/javascripts/views/templates/servers/partials/suite_result_details.hbs
@@ -1,6 +1,6 @@
     <p class="helper_text">{{suite.description}}</p>
     <div class="row details">
-      <div class="col-md-5">
+      <div class="col-sm-5">
         <table class="table table-hover report-table nav nav-stacked">
           <tbody>
             {{#each result.tests as |test|}}
@@ -21,7 +21,7 @@
           </tbody>
         </table>
       </div>
-      <div class="col-md-7 tab-content test-results">
+      <div class="col-sm-7 tab-content test-results">
         {{> test_result test=result.tests.[0]}}
       </div>
     </div>

--- a/app/assets/javascripts/views/templates/servers/starburst_children_chart.hbs
+++ b/app/assets/javascripts/views/templates/servers/starburst_children_chart.hbs
@@ -1,20 +1,20 @@
 <div class="row spec-headers">
-  <div class="col-md-4 spec-headers-specification">Specification</div>
-  <div class="col-md-3 col-md-offset-4 spec-headers-passing">% Passing</div>
+  <div class="col-sm-4 spec-headers-specification">Specification</div>
+  <div class="col-sm-3 col-sm-offset-4 spec-headers-passing">% Passing</div>
 </div>
 <div class="row spec-headers-table">
-  <div class="col-md-12">
+  <div class="col-sm-12">
   {{#each children as |child|}}
     <div class="row spec-row">
-      <div class="col-md-5 spec-title">{{child.name}}</div>
-      <div class="col-md-4 spec-bar-graph">
+      <div class="col-sm-5 spec-title">{{child.name}}</div>
+      <div class="col-sm-4 spec-bar-graph">
         <div class="progress-small">
           <div class="progress-bar progress-bar-success" role="progressbar" data-original-title="" title="" style="width: {{child.percentPassed}}%;"></div>
           <div class="progress-bar progress-bar-danger" role="progressbar" data-original-title="" title="" style="width: {{child.percentFailed}}%;"></div>
           <div class="progress-bar progress-bar-untested" role="progressbar" data-original-title="" title="" style="width: {{child.percentUntested}}%;"></div>
         </div>
       </div>
-      <div class="col-md-3 spec-percent-passing">{{child.percentPassed}}%</div>
+      <div class="col-sm-3 spec-percent-passing">{{child.percentPassed}}%</div>
     </div>
   {{/each}}
   </div>

--- a/app/assets/javascripts/views/templates/servers/suite_group.hbs
+++ b/app/assets/javascripts/views/templates/servers/suite_group.hbs
@@ -1,8 +1,8 @@
 <div class="suite-group">
   <a class="btn btn-accent-inverse" role="button" data-toggle="collapse" href="#testGroup_{{group.id}}" aria-expanded="false" aria-controls="testGroup">
     <div class="row">
-      <div class="col-md-10">{{group.title}}</div>
-      <div class="col-md-2"><span class="suite-count">{{group.suites.length}} suite{{pluralize? group.suites.length}}</span></div>
+      <div class="col-sm-10">{{group.title}}</div>
+      <div class="col-sm-2"><span class="suite-count">{{group.suites.length}} suite{{pluralize? group.suites.length}}</span></div>
     </div>
   </a>
   <div class="collapse suite-group-body" id="testGroup_{{group.id}}">

--- a/app/assets/javascripts/views/templates/servers/suite_select.hbs
+++ b/app/assets/javascripts/views/templates/servers/suite_select.hbs
@@ -12,7 +12,7 @@
   <div class="panel-collapse collapse" id="{{suite.id}}_details" aria-expanded="false" style="height: 0px;">
     <p class="helper_text">{{suite.description}}</p>
     <div class="row details">
-      <div class="col-md-5">
+      <div class="col-sm-5">
         <table class="table report-table nav nav-stacked">
           <tbody>
             {{#each suite.methods as |method|}}
@@ -28,7 +28,7 @@
           </tbody>
         </table>
       </div>
-      <div class="col-md-7 tab-content test-results">
+      <div class="col-sm-7 tab-content test-results">
         {{> test_result test=suite.methods.[0]}}
       </div>
     </div>

--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -3,6 +3,9 @@
     margin-top: 50px;
     margin-bottom: 50px;
   }
+  &.servers-show {
+    min-width: 1170px;
+  }
 }
 
 .palette {

--- a/app/assets/stylesheets/_server.scss
+++ b/app/assets/stylesheets/_server.scss
@@ -202,11 +202,6 @@
     line-height: 1em;
   }
 
-  .starburst {
-    width: 300px;
-    height: 300px;
-  }
-
 }
 
 // ------------------------- SERVER TIME ----------------------------------- //

--- a/app/assets/stylesheets/_tables.scss
+++ b/app/assets/stylesheets/_tables.scss
@@ -107,6 +107,7 @@ table > tbody > tr > td {
 .table.report-table > tbody > tr > td:last-child {
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
+  word-wrap: break-word;
 }
 
 .table-hover > tbody > tr:hover{

--- a/app/assets/stylesheets/_tests.scss
+++ b/app/assets/stylesheets/_tests.scss
@@ -10,9 +10,7 @@
   .warning {color: $result-warning;}
   .details {
     min-height: 250px;
-    max-height: 500px;
     margin-top: 20px;
-    overflow: auto;
     h4 {
       &.heading {
         text-align: center;
@@ -60,6 +58,10 @@
     border-top: 2px solid $structure;
     border-bottom: 2px solid $structure;
     margin-bottom: 20px;
+    > div {
+        max-height: 500px;
+        overflow-y: auto;
+    }
   }
   .tab-content{
     border: 5px solid $base;

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -54,7 +54,8 @@ class TestRun
     end
 
     # pull all the tests into memory with .map {} so that the cursor doesn't time out
-    self.tests.map {|n| n}.each_with_index do |t, i|
+    # sort because mongoid does not retain order using self.tests; only retains order when using test_ids
+    self.tests.map {|n| n}.sort {|a, b| test_ids.index(a.id) <=> test_ids.index(b.id) }.each_with_index do |t, i|
       return false if TestRun.find(self.id).status == 'cancelled'
 
       Rails.logger.info "\t #{i}/#{self.tests.length}: #{self.server.name}(#{self.server.url})"

--- a/app/views/components/_server_summary_carousel.html.erb
+++ b/app/views/components/_server_summary_carousel.html.erb
@@ -16,7 +16,7 @@
       <div class="row">
         <% first = false %>
         <% server_page.each do |server| %>
-          <div class="col-md-4">
+          <div class="col-sm-4">
             <%= render partial: "components/server_summary", locals: {server: server, synchronized: true}%>
           </div>
         <% end %>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container main">
 
   <div class="banner row">
-    <div class="col-md-12">
+    <div class="col-sm-12">
       <div class="alert alert-info alert-dismissible dstu-update" role="alert">
         The tests shown on this dashboard are under active development, and test runs shown may be out of date. As a result, the results displayed below do not necessarily represent the true status of a particular server with respect to tested FHIR features. To view the complete test results for the servers listed below, please visit the <a href="/">Crucible home page</a>.
       </div>
@@ -9,16 +9,16 @@
   </div>
 
     <div class="row">
-      <div class="col-md-12">
+      <div class="col-sm-12">
         <div class="palette dashboard dashboard-element" data-dashboard-id="<%=@id%>">
           <% @suites.each do |suite| %>
             <div class="dash-suite-object">
               <div class="row dashboard-header">
-                <div class="col-md-12">
+                <div class="col-sm-12">
                   <h4><%= suite.name.titleize %><%if suite.details%> <a data-toggle="collapse" href="#dashboard-metadata-<%=suite.id%>">(more info)</a><%end%></h4>
                   <div class="collapse" id="dashboard-metadata-<%=suite.id%>">
                     <div class="row">
-                      <div class="col-md-12">
+                      <div class="col-sm-12">
                         <ul class="nav nav-pills" data-tabs="tabs">
                           <%
                             i=0
@@ -36,7 +36,7 @@
                           %>
                             <div class="tab-pane<%if i==1%> active<%end%>" id="<%=suite.id%>_<%=key.parameterize%>">
                               <div class="row">
-                                <div class="col-md-12">
+                                <div class="col-sm-12">
                                   <p><%= value %></p>
                                 </div>
                               </div>
@@ -49,7 +49,7 @@
                 </div>
               </div>
               <div class="row dashboard-body">
-                <div class="col-md-12" id="suite_results_<%=suite.id%>">
+                <div class="col-sm-12" id="suite_results_<%=suite.id%>">
                   <i class="fa fa-lg fa-fw fa-spinner fa-pulse"></i> Loading
                 </div>
               </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -9,7 +9,7 @@
 
 <div class="container main">
   <div class="banner row">
-    <div class="col-md-12">
+    <div class="col-sm-12">
       <div class="alert alert-warning alert-dismissible CFP-update" role="alert">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
         <strong>Crucible DSTU 2:</strong> This version of Crucible aligns with the <a href="http://hl7.org/fhir/DSTU2/index.html">DSTU 2 version of FHIR</a>.  There is also <a href="https://beta.projectcrucible.org/">a version of Crucible that aligns with the STU 3 version of FHIR</a>.
@@ -19,7 +19,7 @@
 
   <form action="/servers" method="post" id="new-server-form">
 <!--     <div class="banner row">
-      <div class="col-md-12">
+      <div class="col-sm-12">
         <div class="alert alert-danger alert-dismissible dstu-update" role="alert">
           <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
           <strong>Attention!</strong> banner message
@@ -27,17 +27,17 @@
       </div>
     </div>
  -->    <div class="row form landing-page">
-      <div class="col-md-1">
+      <div class="col-sm-1">
         <div class="picture landing-page visible-lg-block">
           <img src="<%= image_path("logo_dark.png")%>" alt="Crucible">
         </div>
       </div>
-      <div class="col-md-11 landing-page-form">
+      <div class="col-sm-11 landing-page-form">
         <div class="row">
-          <div class="col-md-10">
+          <div class="col-sm-10">
             <input placeholder="FHIR Server URL" type="text" name="server[url]" class="form-control">
           </div>
-          <div class="col-md-2">
+          <div class="col-sm-2">
             <input type="submit" class="btn begin" value="Begin"></input>
           </div>
         </div>
@@ -46,7 +46,7 @@
 
     <!--
     <div class="row form">
-      <div class="col-md-10">
+      <div class="col-sm-10">
         <div class="form-group">
           {{#if multiServer}}
             {{input value=server2 class="form-control" placeholder="Comparison FHIR Server URL"}}
@@ -54,7 +54,7 @@
         </div>
       </div>
 
-      <div class="col-md-2">
+      <div class="col-sm-2">
         {{#if multiServer}}
           <a {{action 'removeUrl'}} class="toggle-info" ><i class="fa fa-minus fa-fw"></i> Remove Server</a>
         {{else}}

--- a/app/views/servers/_authorization.html.erb
+++ b/app/views/servers/_authorization.html.erb
@@ -39,7 +39,7 @@
         </table>
       </div>
       <div class="row">
-        <div class="col-md-4">
+        <div class="col-sm-4">
           <button type="submit" class="btn btn-primary authorize_form_element" id="authorize_app">Authorize App</button>
         </div>
       </div>

--- a/app/views/servers/_individual_results.html.erb
+++ b/app/views/servers/_individual_results.html.erb
@@ -24,7 +24,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">R001: Result headers on normal read.</h4>
             <!---->
@@ -84,7 +84,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">R002: Read unknown resource type.</h4>
             <!---->
@@ -128,7 +128,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">R003: Read non-existing resource id.</h4>
             <!---->
@@ -179,7 +179,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">R004: Read invalid format resource id</h4>
             <div class="media test-message">
@@ -250,7 +250,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">CT01: Request xml using headers</h4>
             <!---->
@@ -303,7 +303,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">CT02A: Request [xml] using [_format]</h4>
             <!---->
@@ -356,7 +356,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">CT02B: Request [text/xml] using [_format]</h4>
             <!---->
@@ -409,7 +409,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">CT02C: Request [application/xml] using [_format]</h4>
             <!---->
@@ -462,7 +462,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">CT02D: Request [application/xml+fhir] using [_format]</h4>
             <!---->
@@ -515,7 +515,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">CT03: Request json using headers</h4>
             <!---->
@@ -568,7 +568,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">CT04A: Request [json] using [_format]</h4>
             <!---->
@@ -621,7 +621,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">CT04B: Request [text/json] using [_format]</h4>
             <!---->
@@ -674,7 +674,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">CT04C: Request [application/json] using [_format]</h4>
             <!---->
@@ -727,7 +727,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">CT04D: Request [application/json+fhir] using [_format]</h4>
             <!---->
@@ -780,7 +780,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT01: Request xml and json using headers</h4>
             <!---->
@@ -833,7 +833,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT02: Request xml and json using [_format]</h4>
             <!---->
@@ -886,7 +886,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT03: Request xml Bundle using headers</h4>
             <!---->
@@ -939,7 +939,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT04A: Request [xml] Bundle using [_format]</h4>
             <!---->
@@ -992,7 +992,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT04B: Request [text/xml] Bundle using [_format]</h4>
             <!---->
@@ -1045,7 +1045,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT04C: Request [application/xml] Bundle using [_format]</h4>
             <!---->
@@ -1098,7 +1098,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT04D: Request [application/xml+fhir] Bundle using [_format]</h4>
             <!---->
@@ -1151,7 +1151,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT05: Request json Bundle using headers</h4>
             <!---->
@@ -1204,7 +1204,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT06A: Request [json] Bundle using [_format]</h4>
             <!---->
@@ -1257,7 +1257,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT06B: Request [text/json] Bundle using [_format]</h4>
             <!---->
@@ -1310,7 +1310,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT06C: Request [application/json] Bundle using [_format]</h4>
             <!---->
@@ -1363,7 +1363,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">FT06D: Request [application/json+fhir] Bundle using [_format]</h4>
             <!---->
@@ -1416,7 +1416,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">HI01: History for specific resource</h4>
             <div class="media test-message">
@@ -1483,7 +1483,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">HI01.1: History transactions entries</h4>
             <div class="media test-message">
@@ -1550,7 +1550,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">HI02: full history of a resource by id with since</h4>
             <div class="media test-message">
@@ -1617,7 +1617,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">HI03: individual history versions</h4>
             <div class="media test-message">
@@ -1684,7 +1684,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">HI04: history for missing resource</h4>
             <div class="media test-message">
@@ -1753,7 +1753,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">HI06: all history for resource with since</h4>
             <div class="media test-message">
@@ -1820,7 +1820,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">HI08: all history whole system with since</h4>
             <div class="media test-message">
@@ -1887,7 +1887,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">HI09: resource history page forward</h4>
             <div class="media test-message">
@@ -1943,7 +1943,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">HI10: resource history page backwards</h4>
             <div class="media test-message">
@@ -1999,7 +1999,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">HI11: first page full history</h4>
             <!---->
@@ -2051,7 +2051,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X000_Binary: Binary: Read Type</h4>
             <!---->
@@ -2099,7 +2099,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X010_Binary: Binary: Create New</h4>
             <div class="media test-message">
@@ -2152,7 +2152,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X020_Binary: Binary: Read Existing</h4>
             <div class="media test-message">
@@ -2245,7 +2245,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X030_Binary: Binary: Update Existing</h4>
             <div class="media test-message">
@@ -2308,7 +2308,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X040_Binary: Binary: Read History of existing</h4>
             <div class="media test-message">
@@ -2361,7 +2361,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X050_Binary: Binary: Version read existing</h4>
             <div class="media test-message">
@@ -2414,7 +2414,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X055_Binary: Binary: Previous version read existing</h4>
             <div class="media test-message">
@@ -2466,7 +2466,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X060_Binary: Binary: Validate</h4>
             <div class="media test-message">
@@ -2532,7 +2532,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X065_Binary: Binary: Validate Existing</h4>
             <div class="media test-message">
@@ -2598,7 +2598,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X067_Binary: Binary: Validate against a profile</h4>
             <div class="media test-message">
@@ -2664,7 +2664,7 @@
     </div>
     <div class="panel-collapse collapse" id="panel">
       <div class="row">
-        <div class="col-md-12 tab-content">
+        <div class="col-sm-12 tab-content">
           <div class="media">
             <h4 class="test-run-result-id">X070_Binary: Binary: Delete Existing</h4>
             <div class="media test-message">

--- a/app/views/servers/_test_run_report.html.erb
+++ b/app/views/servers/_test_run_report.html.erb
@@ -10,14 +10,14 @@
     </span>
   </div>
   <div class="row server-fhir-specification section-data">
-    <div class="col-md-5 spec-starburst-chart">
-      <div class="col-md-11">
+    <div class="col-sm-5 spec-starburst-chart">
+      <div class="col-sm-11">
         <div class="starburst-header">
         </div>
         <%= render partial: "components/server_summary", locals: {server: server, noHeader: true}%>
       </div>
     </div>
-    <div class="col-md-7 spec-details">
+    <div class="col-sm-7 spec-details">
       <!-- details bars go here for children -->
     </div>
   </div>

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -1,6 +1,6 @@
-<div class="container main">
+<div class="container main servers-show">
   <div class="row content">
-    <div class="col-md-12">
+    <div class="col-sm-12">
       <div class="palette report">
           <% if flash[:notice] %>
             <div class="alert alert-success alert-dismissible" role="alert">
@@ -15,7 +15,7 @@
             </div>
           <% end %>
         <div class="row">
-          <div class="col-md-12 server-test-details">
+          <div class="col-sm-12 server-test-details">
             <!-- START: server name and url -->
             <div class="server-details" data-server-id="<%=@server.id%>">
               <div class="authorize-icon pull-left">
@@ -41,13 +41,13 @@
               <a class="edit-server-name-icon editToggle pull-left"><i class="fa fa-pencil-square-o edit-server-name"></i></a>
               <div class="edit-panel row hide editToggle">
                 <form id="server_update_form">
-                  <div class="col-md-6">
+                  <div class="col-sm-6">
                     <input id="edit-server-name-dialogue" name="name" value='<%= @server.name %>' placeholder='Server Name'>
                     <input id="edit-server-url-dialogue" name="url" value='<%= @server.url %>' placeholder='Server URL'>
                     <input id="edit-server-tags-dialogue" name="tags" value='<%= @server.tags.join(',') %>' placeholder="Add Tag" data-role="tagsinput">
                     <label id="edit-server-tags-dialogue-error" class="error" for="edit-server-tags-dialogue" style="display:none"></label>
                   </div>
-                  <div class="col-md-3">
+                  <div class="col-sm-3">
                     <!-- button submits without a type=button -->
                     <button class="btn secondary submit-server-name"><i class="fa fa-lg fa-fw fa-spinner fa-pulse hide"> </i>Save</button>
                     <button type="button" class="btn secondary cancel-server-name">Cancel</button>                    
@@ -80,7 +80,7 @@
             <div class="tab-pane test-results active" id="test-data">
               <div class="test-executor" data-server-id="<%=@server.id %>" data-current-test-run-id="<%=@currentTestRunId %>" data-progress="execution-progress">
                 <!-- START: Left side, with filters -->
-                <div class="col-md-3">
+                <div class="col-sm-3">
                   <div class="filter">
                     <%= render partial: "components/server_summary", locals: {server: @server, noHeader: true}%>
                     <div>
@@ -108,13 +108,13 @@
                   </div>
                 </div>
                 <!-- END: Left side, with filters -->
-                <div class="col-md-9 tab-content-holder">
+                <div class="col-sm-9 tab-content-holder">
                   <!-- grouping option selectors -->
                   <div class="panel-group test-results" id="accordion" role="tablist" aria-multiselectable="true">
                     <div class="test-result-error"></div>
                     <div class="test-result-loading"><i class="fa fa-lg fa-fw fa-spinner fa-pulse"></i> Loading...</div>
                     <div class="button-holder row hide">
-                      <div class="col-md-9 suite-selectors">
+                      <div class="col-sm-9 suite-selectors">
                         <a class="selectDeselectAll" data-toggle="tooltip" data-placement="top" title="Select/Deselect All Suites"><i class="fa fa-check"></i></a>
                         <a class="expandCollapseAll" data-toggle="tooltip" data-placement="top" title="Expand/Collapse All Suites"><i class="fa fa-expand"></i></a>
                         <a class="change-test-run" data-toggle="tooltip" data-placement="top" title="Select Past Test Run"><i class="fa fa-clock-o"></i></a>
@@ -127,13 +127,13 @@
                           <i class="fa fa-close clear-past-run-data" style="display: none" data-toggle="tooltip" data-placement="top" title="Clear Past Test Run Data"></i>
                         </span>
                       </div>
-                      <div class="col-md-3">
+                      <div class="col-sm-3">
                         <!-- <a class="link-btn pull-right">Execute&nbsp;<i class="fa fa-arrow-circle-right"></i></a> -->
                         <button class="btn execute">
                           Execute
                         </button>
                       </div>
-                      <div class="col-md-3 col-md-offset-9">
+                      <div class="col-sm-3 col-sm-offset-9">
                         <button class="btn cancel" data-toggle="modal" data-target="#cancel-modal" style="display:none">
                             Cancel
                         </button>
@@ -154,7 +154,7 @@
               </div>
             </div>
             <div class="tab-pane" id="test-run-summary-data">
-              <div class="col-md-12">
+              <div class="col-sm-12">
                 <%= render partial: 'test_run_report', locals: {server: @server}%>
               </div>
             </div>


### PR DESCRIPTION
Cherry pick UI upgrades made to STU3.  Probably worth a quick run through to make sure that nothing broke, but these changes are isolated away from the other STU3 work so it should be ok.  What has changed:
- Resizing the browser on the server view page will no longer attempt to resize responsively (unless you get really, really small)
- Panes within a test result should scroll separately
- Submitting a test run with tests that aren't alphabetically listed due to categories in order should execute from top to bottom (and not alphabetically)
- expand / collapse and check all/uncheck all buttons should track pretty well to the current state after you change runs, clear runs, etc.
