### PR TITLE
Updated ServersController#aggregate_run to return _and_ render nothing if aggregate run doesn't exist

### DIFF
--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -120,11 +120,12 @@ class ServersController < ApplicationController
   def aggregate_run
     server = Server.find(params[:server_id])
     aggregate_run = server.aggregate_run
+    render :nothing => true unless aggregate_run
     return unless aggregate_run
     if (params[:only_failures])
       aggregate_run.results.select! {|r| r if r['status'] != 'pass'}
     end
-    render json: server.aggregate_run
+    render json: aggregate_run
   end
 
   def oauth_params


### PR DESCRIPTION
Also, we were not returning the correct object as JSON before. Now we're actually using the `aggregate_run` variable that gets generated.

This is the STU3 version of the pull request.
