### PR TITLE
Add initial google analytics tracking code.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,16 @@
   <%= csrf_meta_tags %>
   <link rel="icon" href="<%= image_path("favicon.ico")%>">
 
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-79773092-1', 'auto');
+    ga('send', 'pageview');
+  </script>
+
 </head>
 <body>
 


### PR DESCRIPTION
A couple of minor potential issues:
1. If somebody else runs crucible themselves, it may show up in our dashboard (though not under projectcrucible.org domain, unless they are pathological and are messing with their local dns or host file).  Putting the siteid in an ENV variable or something seemed like a pain though.  What do you think?
2. I just stuck the tracking javascript in the application.html.erb.  There might be a more rails-like way of doing this.
3. I am just tracking page loads.  We can add more events if we want though (like running tests, etc).

Happy to update this PR to fix any/all of the above.
