### PR TITLE
Only include the GA.js script in the Rails production environment

### DIFF
--- a/app/assets/javascripts/views/component/authorization.coffee
+++ b/app/assets/javascripts/views/component/authorization.coffee
@@ -1,4 +1,4 @@
-$(window).on('load', ->
+$(document).ready( -> 
   new Crucible.Authorization()
 )
 

--- a/app/assets/javascripts/views/component/conformance.coffee
+++ b/app/assets/javascripts/views/component/conformance.coffee
@@ -1,4 +1,4 @@
-$(window).on('load', ->
+$(document).ready( -> 
   new Crucible.Conformance()
 )
 

--- a/app/assets/javascripts/views/component/dashboard.coffee
+++ b/app/assets/javascripts/views/component/dashboard.coffee
@@ -1,4 +1,4 @@
-$(window).on('load', ->
+$(document).ready( -> 
   new Crucible.Dashboard()
 )
 

--- a/app/assets/javascripts/views/component/server-details.coffee
+++ b/app/assets/javascripts/views/component/server-details.coffee
@@ -1,4 +1,4 @@
-$(window).on('load', ->
+$(document).ready( -> 
   new Crucible.ServerDetails()
 )
 

--- a/app/assets/javascripts/views/component/summary.coffee
+++ b/app/assets/javascripts/views/component/summary.coffee
@@ -1,4 +1,4 @@
-$(window).on('load', -> 
+$(document).ready( -> 
   new Crucible.Summary()
 )
 
@@ -17,7 +17,7 @@ class Crucible.Summary
       serverId = summaryElement.data('serverId')
       if serverId?
         $.getJSON("/servers/#{serverId}/summary.json")
-          .success((data) => 
+          .success((data) =>
             if (data.summary)
               starburstElement = summaryElement.find('.starburst')
               summaryElement.show()

--- a/app/assets/javascripts/views/component/test-executor.coffee
+++ b/app/assets/javascripts/views/component/test-executor.coffee
@@ -1,4 +1,4 @@
-$(window).on('load', ->
+$(document).ready( -> 
   new Crucible.TestExecutor()
 )
 

--- a/app/assets/javascripts/views/component/test-run-report.coffee
+++ b/app/assets/javascripts/views/component/test-run-report.coffee
@@ -1,4 +1,4 @@
-$(window).on('load', -> 
+$(document).ready( ->  
   new Crucible.TestRunReport()
 )
 

--- a/app/assets/javascripts/views/home/index.coffee.erb
+++ b/app/assets/javascripts/views/home/index.coffee.erb
@@ -1,4 +1,4 @@
-$(window).on('load', ->
+$(document).ready( -> 
   new Crucible.Home()
 )
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,15 +8,17 @@
   <%= csrf_meta_tags %>
   <link rel="icon" href="<%= image_path("favicon.ico")%>">
 
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  <% if Rails.env.production? %>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    ga('create', 'UA-79773092-1', 'auto');
-    ga('send', 'pageview');
-  </script>
+      ga('create', 'UA-79773092-1', 'auto');
+      ga('send', 'pageview');
+    </script>
+  <% end %>
 
 </head>
 <body>
@@ -39,7 +41,7 @@
           <li>{{#link-to 'servers.index' classNames="navButton"}}Servers{{/link-to}}</li>
           <li><a href="#" class="navButton" {{action 'invalidateSession'}}>Logout</a></li>
         {{else}}
- -->          
+ -->
           <li><a href="/" class="navButton">Server Test</a></li>
           <li><a href="mailto:fhir-testing-list@lists.mitre.org?subject=Crucible" class="navButton">Contact Us</a></li>
 <!--           <li><a href="/users/login" class="navButton" {{action 'openLoginModal'}}>Login</a></li>


### PR DESCRIPTION
Problem: The Google Analytics script doesn't run well inside the Mitre network, and so blocks the page for a period of time in development.

Solution: Only include the `<script>` block for calling the GA.js object if Rails is running in production mode.
