### PR TITLE
Dashboard details

### DIFF
--- a/app/assets/stylesheets/_alert.scss
+++ b/app/assets/stylesheets/_alert.scss
@@ -21,5 +21,8 @@
         text-decoration: underline;
       }
     }
-  }	
+    a {
+      color: #337ab7;
+    }
+  }
 }

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -2,6 +2,7 @@ class DashboardsController < ApplicationController
 
   def show
     @id = params[:id]
+    @dashboard = Dashboard.where(tag: @id).first
     @suites = Test.where({tags: @id}).sort! {|l,r| l.name <=> r.name}
   end
 
@@ -52,9 +53,9 @@ class DashboardsController < ApplicationController
   def backfill_requests(test_result_ids, results)
     test_results_by_id = {}
     TestResult.find(test_result_ids).each {|tr| test_results_by_id[tr.id] = tr} rescue 'missing results'
-    results.values.each do |by_suite| 
+    results.values.each do |by_suite|
       by_suite.values.each do |trs|
-        trs[:results].each do |tr| 
+        trs[:results].each do |tr|
           tr['requests'] = test_results_by_id[tr['test_result_id']].result.select{|x| x['id'] == tr['id']}.first['requests'] if test_results_by_id[tr['test_result_id']]
         end
       end

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -4,4 +4,6 @@ class Dashboard
   field :title, type: String
   field :description, type: String
   field :tag, type: String
+
+  index tag: 1
 end

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -1,0 +1,7 @@
+class Dashboard
+  include Mongoid::Document
+
+  field :title, type: String
+  field :description, type: String
+  field :tag, type: String
+end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -2,8 +2,16 @@
 
   <div class="banner row">
     <div class="col-sm-12">
-      <div class="alert alert-info alert-dismissible dstu-update" role="alert">
+      <div class="alert alert-info dstu-update" role="alert">
         The tests shown on this dashboard are under active development, and test runs shown may be out of date. As a result, the results displayed below do not necessarily represent the true status of a particular server with respect to tested FHIR features. To view the complete test results for the servers listed below, please visit the <a href="/">Crucible home page</a>.
+      </div>
+    </div>
+  </div>
+
+  <div class="banner row">
+    <div class="col-sm-12">
+      <div class="well">
+        <%= @dashboard.title %>: <% @dashboard.description %>
       </div>
     </div>
   </div>
@@ -22,7 +30,7 @@
                         <ul class="nav nav-pills" data-tabs="tabs">
                           <%
                             i=0
-                            suite.details.keys.each do |key| 
+                            suite.details.keys.each do |key|
                             i+=1
                           %>
                             <li role="presentation" <%if i==1%>class="active"<%end%>><a href="#<%=suite.id%>_<%=key.parameterize%>" data-toggle="tab"><%=key%></a></li>
@@ -31,7 +39,7 @@
                         <div class="tab-content" id="dashboard-metadata-content">
                           <%
                             i=0
-                            suite.details.each do |key, value| 
+                            suite.details.each do |key, value|
                             i+=1
                           %>
                             <div class="tab-pane<%if i==1%> active<%end%>" id="<%=suite.id%>_<%=key.parameterize%>">
@@ -77,5 +85,3 @@
   </div>
 
 </div>
-
-

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -3,7 +3,7 @@
   <div class="banner row">
     <div class="col-sm-12">
       <div class="alert alert-info dstu-update" role="alert">
-        The tests shown on this dashboard are under active development, and test runs shown may be out of date. As a result, the results displayed below do not necessarily represent the true status of a particular server with respect to tested FHIR features. To view the complete test results for the servers listed below, please visit the <a href="/">Crucible home page</a>.
+        The tests shown on this dashboard are under active development, and test runs shown may be out of date. As a result, the results displayed below do not necessarily represent the true status of a particular server with respect to tested FHIR features. To view the complete test results for the servers listed below, please visit the <%= link_to 'Crucible home page', root_url %>.
       </div>
     </div>
   </div>
@@ -11,7 +11,7 @@
   <div class="banner row">
     <div class="col-sm-12">
       <div class="well">
-        <%= @dashboard.title %>: <% @dashboard.description %>
+        <%= @dashboard.title %>: <%= @dashboard.description %>
       </div>
     </div>
   </div>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -8,13 +8,15 @@
     </div>
   </div>
 
-  <div class="banner row">
-    <div class="col-sm-12">
-      <div class="well">
-        <%= @dashboard.title %>: <%= @dashboard.description %>
+  <% if @dashboard %>
+    <div class="banner row">
+      <div class="col-sm-12">
+        <div class="well">
+          <%= @dashboard.title %>: <%= @dashboard.description %>
+        </div>
       </div>
     </div>
-  </div>
+  <% end %>
 
     <div class="row">
       <div class="col-sm-12">


### PR DESCRIPTION
Added `#{title}: #{description}` to Dashboard pages, as pulled from a `Dashboard` object within Crucible. If no `Dashboard` object is present for a given tag, the title `<div>` will not be displayed, so this is a backwards-compatible change if no title/description objects have been added.

In the `Dashboard` object:
- `title`: The string before the `:` on the show page
- `description`: The string after the `:` on the show page
- `tag`: The string for which this title/description should be displayed, e.g. `argonaut`.
