### PR TITLE
Updates to dashboard to add a legend, and move description

### DIFF
--- a/app/assets/javascripts/views/component/dashboard.coffee
+++ b/app/assets/javascripts/views/component/dashboard.coffee
@@ -5,6 +5,7 @@ $(document).ready( ->
 class Crucible.Dashboard
 
   statusWeights: {'none': 0, 'pass': 1, 'skip': 2, 'fail': 3, 'error': 4}
+  statusLabels: {'none': 'Not Run', 'pass': 'Passing', 'skip': 'Skipped', 'fail': 'Failing', 'error': 'Error'}
 
   templates:
     serverResultsRow: 'views/templates/dashboards/server_result_row'
@@ -17,7 +18,6 @@ class Crucible.Dashboard
     return unless @element.length
     @id = this.element.data('dashboard-id')
     @renderServerResults()
-    # @bindToolTips()
 
   renderServerResults: =>
     $.getJSON("/dashboards/#{@id}/results.json").success((data) =>
@@ -31,6 +31,7 @@ class Crucible.Dashboard
           $(serverResults).each (i, serverResult) =>
             suiteStatus = serverResult.status if @statusWeights[suiteStatus] < @statusWeights[serverResult.status]
           suite.status = suiteStatus
+          suite.statusLabel = @statusLabels[suiteStatus]
           serverResults = suite.methods if serverResults.length == 0
           html = HandlebarsTemplates[@templates.serverResultsRow]({server: server, suite: suite, lastUpdated: lastUpdated, result: {tests: serverResults}})
           $("#suite_results_#{suite.id}").append(html)
@@ -41,6 +42,7 @@ class Crucible.Dashboard
               @addClickRequestDetailsHandler(test, suiteElement)
             @addClickTestHandler(test, suiteElement)
       $('.results-rectangle').tooltip()
+      $('.results-circle').tooltip()
     )
 
   addClickTestHandler: (test, suiteElement) => 

--- a/app/assets/javascripts/views/templates/dashboards/server_result_row.hbs
+++ b/app/assets/javascripts/views/templates/dashboards/server_result_row.hbs
@@ -9,7 +9,7 @@
     <div class="col-sm-4 results">
       <span> 
         {{#each result.tests as |testResult|}}
-          <span class="results-rectangle" data-toggle="tooltip" data-placement="top" title="{{testResult.description}}">
+          <span class="results-rectangle" data-toggle="tooltip" data-placement="top" title="{{testResult.description}} ({{#if testResult.status}}{{testResult.status}}{{else}}not run{{/if}})">
             <svg width="18" height="18">
               <rect x="0" y="0" rx="3" ry="3" width="18" height="18" class="{{testResult.status}}" fill=""/>
             </svg>

--- a/app/assets/javascripts/views/templates/dashboards/server_result_row.hbs
+++ b/app/assets/javascripts/views/templates/dashboards/server_result_row.hbs
@@ -1,9 +1,11 @@
 <div class="dash-elem">
   <div class="row dash-row">
     <div class="col-sm-4 server-name">
-      <svg width="18" height="18">
-        <circle cx="9" cy="9" r="9" class="{{suite.status}}"/>
-      </svg>
+      <span class="results-circle" data-toggle="tooltip" data-placement="top" title="{{suite.statusLabel}}">
+        <svg width="18" height="18">
+          <circle cx="9" cy="9" r="9" class="{{suite.status}}"/>
+        </svg>
+      </span>
       <a data-toggle="collapse" href="#dash-{{server._id.$oid}}-{{suite.id}}">{{server.name}}</a>
     </div>
     <div class="col-sm-4 results">

--- a/app/assets/stylesheets/_dashboard.scss
+++ b/app/assets/stylesheets/_dashboard.scss
@@ -51,7 +51,7 @@
   margin-bottom: 30px;
 }
 
-.dashboard-body{
+.dashboard-body, .legend{
   font-size: 16px;
   p{display: inline;}
   .server-name p{
@@ -114,6 +114,12 @@
         color: $brand-secondary;
       }
     }
+  }
+}
+
+.legend {
+  svg {
+    overflow: visible;
   }
 }
 

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -22,11 +22,9 @@
           <% {'none': 'Not Run', 'pass': 'Passing', 'skip': 'Skipped', 'fail': 'Failing'}.each do |key, desc| %>
             <div class="col-sm-3">
               <%= desc %>: 
-              <span class="results-rectangle" data-toggle="tooltip" data-placement="middle" title="<%= desc %>">
-                <svg width="18" height="18">
-                  <rect x="0" y="3" rx="3" ry="3" width="18" height="18" class="<%= key %>" fill=""></rect>
-                </svg>
-              </span>
+              <svg width="18" height="18">
+                <rect x="0" y="3" rx="3" ry="3" width="18" height="18" class="<%= key %>" fill=""></rect>
+              </svg>
             </div>
           <% end %>
         </div>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -2,72 +2,88 @@
 
   <div class="banner row">
     <div class="col-sm-12">
+      <% if @dashboard %>
+        <h2><%= @dashboard.title %></h2>
+      <% end %>
       <div class="alert alert-info dstu-update" role="alert">
-        The tests shown on this dashboard are under active development, and test runs shown may be out of date. As a result, the results displayed below do not necessarily represent the true status of a particular server with respect to tested FHIR features. To view the complete test results for the servers listed below, please visit the <%= link_to 'Crucible home page', root_url %>.
+        <% if @dashboard %>
+          <%= @dashboard.description %>
+        <% else %>
+          The tests shown on this dashboard are under active development, and test runs shown may be out of date. As a result, the results displayed below do not necessarily represent the true status of a particular server with respect to tested FHIR features. To view the complete test results for the servers listed below, please visit the <%= link_to 'Crucible home page', root_url %>.
+        <% end %>
       </div>
     </div>
   </div>
 
-  <% if @dashboard %>
-    <div class="banner row">
-      <div class="col-sm-12">
-        <div class="well">
-          <%= @dashboard.title %>: <%= @dashboard.description %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-
-    <div class="row">
-      <div class="col-sm-12">
-        <div class="palette dashboard dashboard-element" data-dashboard-id="<%=@id%>">
-          <% @suites.each do |suite| %>
-            <div class="dash-suite-object">
-              <div class="row dashboard-header">
-                <div class="col-sm-12">
-                  <h4><%= suite.name.titleize %><%if suite.details%> <a data-toggle="collapse" href="#dashboard-metadata-<%=suite.id%>">(more info)</a><%end%></h4>
-                  <div class="collapse" id="dashboard-metadata-<%=suite.id%>">
-                    <div class="row">
-                      <div class="col-sm-12">
-                        <ul class="nav nav-pills" data-tabs="tabs">
-                          <%
-                            i=0
-                            suite.details.keys.each do |key|
-                            i+=1
-                          %>
-                            <li role="presentation" <%if i==1%>class="active"<%end%>><a href="#<%=suite.id%>_<%=key.parameterize%>" data-toggle="tab"><%=key%></a></li>
-                          <% end if suite.details %>
-                        </ul>
-                        <div class="tab-content" id="dashboard-metadata-content">
-                          <%
-                            i=0
-                            suite.details.each do |key, value|
-                            i+=1
-                          %>
-                            <div class="tab-pane<%if i==1%> active<%end%>" id="<%=suite.id%>_<%=key.parameterize%>">
-                              <div class="row">
-                                <div class="col-sm-12">
-                                  <p><%= value %></p>
-                                </div>
-                              </div>
-                            </div>
-                          <% end if suite.details %>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="row dashboard-body">
-                <div class="col-sm-12" id="suite_results_<%=suite.id%>">
-                  <i class="fa fa-lg fa-fw fa-spinner fa-pulse"></i> Loading
-                </div>
-              </div>
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="well legend">
+        <div class="container">
+          <% {'none': 'Not Run', 'pass': 'Passing', 'skip': 'Skipped', 'fail': 'Failing'}.each do |key, desc| %>
+            <div class="col-sm-3">
+              <%= desc %>: 
+              <span class="results-rectangle" data-toggle="tooltip" data-placement="middle" title="<%= desc %>">
+                <svg width="18" height="18">
+                  <rect x="0" y="3" rx="3" ry="3" width="18" height="18" class="<%= key %>" fill=""></rect>
+                </svg>
+              </span>
             </div>
           <% end %>
         </div>
       </div>
     </div>
+  </div>
+
+  <div class="row">
+    <div class="col-sm-12">
+      <div class="palette dashboard dashboard-element" data-dashboard-id="<%=@id%>">
+        <% @suites.each do |suite| %>
+          <div class="dash-suite-object">
+            <div class="row dashboard-header">
+              <div class="col-sm-12">
+                <h4><%= suite.name.titleize %><%if suite.details%> <a data-toggle="collapse" href="#dashboard-metadata-<%=suite.id%>">(more info)</a><%end%></h4>
+                <div class="collapse" id="dashboard-metadata-<%=suite.id%>">
+                  <div class="row">
+                    <div class="col-sm-12">
+                      <ul class="nav nav-pills" data-tabs="tabs">
+                        <%
+                          i=0
+                          suite.details.keys.each do |key|
+                          i+=1
+                        %>
+                          <li role="presentation" <%if i==1%>class="active"<%end%>><a href="#<%=suite.id%>_<%=key.parameterize%>" data-toggle="tab"><%=key%></a></li>
+                        <% end if suite.details %>
+                      </ul>
+                      <div class="tab-content" id="dashboard-metadata-content">
+                        <%
+                          i=0
+                          suite.details.each do |key, value|
+                          i+=1
+                        %>
+                          <div class="tab-pane<%if i==1%> active<%end%>" id="<%=suite.id%>_<%=key.parameterize%>">
+                            <div class="row">
+                              <div class="col-sm-12">
+                                <p><%= value %></p>
+                              </div>
+                            </div>
+                          </div>
+                        <% end if suite.details %>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="row dashboard-body">
+              <div class="col-sm-12" id="suite_results_<%=suite.id%>">
+                <i class="fa fa-lg fa-fw fa-spinner fa-pulse"></i> Loading
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
 
  <!-- Modal Response Data-->
   <div class="modal fade" id="data-modal" tabindex="-1" role="dialog" aria-labelledby="Data for test result">


### PR DESCRIPTION
- Added a legend for what the squares in the test results mean
- Moved the dashboard title (if present) to the top of the page, and the description (if present) to the blue text box
- Added passing/failing/not run/skipped status to tooltip for a suite result rectangle
