### PR TITLE
Connectathon bugfixes

### DIFF
--- a/app/assets/javascripts/views/home/index.coffee.erb
+++ b/app/assets/javascripts/views/home/index.coffee.erb
@@ -1,4 +1,4 @@
-$(document).ready( -> 
+$(document).ready( ->
   new Crucible.Home()
 )
 
@@ -7,12 +7,12 @@ class Crucible.Home
   constructor: ->
     @element = $('#new-server-form')
     return unless @element.length
-    jQuery.validator.addMethod("standardPort", (value, element) -> 
+    jQuery.validator.addMethod("standardPort", (value, element) ->
       if (value)
         url = $('<a/>').get(0)
         url.href = element.value
-        port = port = url.port || (if url.protocol == 'https:' then '443' else '80');
-        return ["8080", "80", "443"].indexOf(port) > 0
+        port = url.port || (if url.protocol == 'https:' then '443' else '80');
+        return ["8080", "80", "443"].indexOf(port) != -1
       else
         return true
     , "Crucible can only test servers on standard ports (80, 8080, 443)")
@@ -20,10 +20,9 @@ class Crucible.Home
 
   registerHandlers: =>
     @element.validate(
-      rules: 
-        "server[url]": 
+      rules:
+        "server[url]":
           required: true
           <%= (Rails.application.config.restrict_localhost_urls) ? "url: true" : "url2: true" %>
           standardPort: <%= Rails.application.config.restrict_test_ports %>
     )
-

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -19,9 +19,9 @@
     <div class="col-sm-12">
       <div class="well legend">
         <div class="container">
-          <% {'none': 'Not Run', 'pass': 'Passing', 'skip': 'Skipped', 'fail': 'Failing'}.each do |key, desc| %>
+          <% {'none' => 'Not Run', 'pass' => 'Passing', 'skip' => 'Skipped', 'fail' => 'Failing'}.each do |key, desc| %>
             <div class="col-sm-3">
-              <%= desc %>: 
+              <%= desc %>:
               <svg width="18" height="18">
                 <rect x="0" y="3" rx="3" ry="3" width="18" height="18" class="<%= key %>" fill=""></rect>
               </svg>


### PR DESCRIPTION
- Switched Dashboard legend display to hashrocket for Ruby 2.1 backwards compatibility
- Set the port check to not return false when the first element in the allowed ports array (`"8080"`) is the port
