### PR TITLE
Performance updates for front page.

### DIFF
--- a/app/assets/javascripts/views/component/server-scroller.coffee
+++ b/app/assets/javascripts/views/component/server-scroller.coffee
@@ -22,7 +22,7 @@ class Crucible.ServerScroller
     )
 
   color: (normalized_score) =>
-    scaled = normalized_score * (colors.length - 1)
+    scaled = normalized_score/100 * (colors.length - 1)
     floor = Math.floor(scaled)
     remainder = scaled - floor
     color = d3.interpolateRgb(colors[floor], colors[floor+1])(remainder)
@@ -42,7 +42,7 @@ class Crucible.ServerScroller
 
   renderChart: (data) =>
 
-    data = _.sortBy(data, (d) => -d.score)
+    data = _.sortBy(data, (d) => -d.percent_passing)
 
     dragstarted = (d) =>
       d3.event.sourceEvent.stopPropagation()
@@ -83,7 +83,7 @@ class Crucible.ServerScroller
       .attr("id", (d) => "scroller-element-#{d.id}")
       .attr("x", 0)
       .attr("y", (d,i) => i * @['height'] / data.length)
-      .style("fill", (d) => @color(d.score))
+      .style("fill", (d) => @color(d.percent_passing))
       .on("click", click)
 
     selected = svg.selectAll('selector')

--- a/app/assets/javascripts/views/component/server-sort.coffee
+++ b/app/assets/javascripts/views/component/server-sort.coffee
@@ -17,17 +17,13 @@ class Crucible.ServerSort
     @element.find('#sortorder_percent_passed').on('click', () =>
       @element.find('a').removeClass('selected')
       @element.find('#sortorder_percent_passed').addClass('selected')
-      @containerElement.find('.server-item')
-        .sort( (a, b) =>
-          return 1 if $(a).data('passed')/$(a).data('total')  < $(b).data('passed')/$(b).data('total')
-          return -1 if $(a).data('passed')/$(a).data('total') > $(b).data('passed')/$(b).data('total')
-          0
-        )
-        .each( (i,e) =>
-          elem = $(e)
-          elem.remove()
-          elem.appendTo(@containerElement)
-        )
+      sortedElements = @containerElement.find('.server-item').toArray().sort (a, b) => $(b).data('percent') - $(a).data('percent')
+
+      @containerElement.empty()
+
+      $.each(sortedElements, (i,el) =>
+        @containerElement.append(el)
+      )
       @containerElement.trigger('sortchange')
       false
     )
@@ -35,17 +31,13 @@ class Crucible.ServerSort
     @element.find('#sortorder_recently_tested').on('click', () =>
       @element.find('a').removeClass('selected')
       @element.find('#sortorder_recently_tested').addClass('selected')
-      @containerElement.find('.server-item')
-        .sort( (a, b) =>
-          return 1 if $(a).data('daysold') > $(b).data('daysold')
-          return -1 if $(a).data('daysold') < $(b).data('daysold')
-          0
-        )
-        .each( (i,e) =>
-          elem = $(e)
-          elem.remove()
-          elem.appendTo(@containerElement)
-        )
+      sortedElements = @containerElement.find('.server-item').toArray().sort (a, b) => $(b).data('lastrun') - $(a).data('lastrun')
+
+      @containerElement.empty()
+
+      $.each(sortedElements, (i,el) =>
+        @containerElement.append(el)
+      )
       @containerElement.trigger('sortchange')
       false
     )

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -10,21 +10,15 @@ class HomeController < ApplicationController
   def server_scrollbar_data
 
     total_tests = Test.all.inject([]) { |a,i| a.concat i.methods}.count
-    servers = Server.where({percent_passing: {"$gte" => 0}}).includes(:summary).all.map do |server|
-      if server.summary and server.summary['compliance'] and server.summary['compliance']['total']
-        compliance = server.summary['compliance']
-        {
-          id: server._id.to_s,
-          name: server.name,
-          percent_run: compliance['total'].to_f / total_tests.to_f,
-          compliance: 0.8,
-          score: compliance['passed'].to_f / compliance['total'].to_f,
-          total: compliance['total'].to_f
-        }
-      end
+    servers = Server.where({percent_passing: {"$gte" => 0}}).map do |server|
+      {
+        id: server._id.to_s,
+        name: server.name,
+        percent_passing: server.percent_passing
+      }
     end
 
-    render json: {total_tests: total_tests, servers: servers.reject {|s| s.nil?}}
+    render json: {total_tests: total_tests, servers: servers}
   end
 
 

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -24,6 +24,7 @@ class Server
   field :default_format, type: String
   field :tags, type: Array, default: []
   embeds_many :scopes
+  field :last_run_at, type: Time
 
   def get_default_scopes
     [{ name: 'launch', description: 'Simulate an EHR launch profile', elem_id: 'launch_check' },

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -104,6 +104,7 @@ class TestRun
     summary = Summary.new({server_id: self.server.id, test_run: self, compliance: compliance, generated_at: Time.now})
     self.server.summary = summary
     self.server.percent_passing = (compliance['passed'].to_f / ([compliance['total'].to_f || 0, 1].max)) * 100.0
+    self.server.last_run_at = Time.now
     summary.save!
     self.server.save!
 

--- a/app/views/components/_server_summary_carousel.html.erb
+++ b/app/views/components/_server_summary_carousel.html.erb
@@ -14,21 +14,20 @@
     <div class="server-rows-container">
       <div class="server-rows">
         <%
-          servers.reject{|s| s.summary.nil?}.each_with_index do |server, rank|
+          servers.each_with_index do |server, index|
         %>
         <div class="server-item" 
           data-serverid="<%= server.id %>" 
-          data-daysold="<%= (Date.today - server.summary.generated_at.to_date).to_i %>" 
-          data-total="<%= server.summary.compliance['total'] %>" 
-          data-passed="<%= server.summary.compliance['passed'] %>">
+          data-lastrun="<%=  (server.last_run_at.to_i || 0) + (index * 0.001) %>" 
+          data-percent="<%= server.percent_passing %>">
           <div class="server-rank">
-            <%= rank + 1 %>
+            <%= index + 1 %>
           </div>
           <%= render partial: "components/server_summary", locals: {server: server, synchronized: true, extended: false}%>
         </div>
       <% end %>
     </div>
-    <% if servers.reject{|s| s.summary.nil?}.count > 15 %>
+    <% if servers.count > 15 %>
       <div class="server-scroller"></div>
     <% end %>
   </div>

--- a/lib/tasks/crucible.rake
+++ b/lib/tasks/crucible.rake
@@ -107,4 +107,14 @@ namespace :crucible do
     TestRun.where(:date.lte => age, :status.in => ["pending", "running"]).update_all(status: 'cancelled')
   end
 
+  desc "upgrade db to store generated_at from summary at the server level"
+  task :copy_generated_at_to_server => [:environment] do
+
+    Server.each do |server|
+      server.last_run_at = server.summary.generated_at unless server.summary.nil?
+      server.save
+    end
+
+  end
+
 end


### PR DESCRIPTION
I couldn't get it to pull in the summary object for each server on the front page query without major performance problems.  So I pulled in the one field that I needed from summaries up into the server collection -- the generated_at field.  This is something that we are already doing with percent_passing, so I'm not adding any addition overhead/complexity that isn't already in there.  We just need to run the new rake task in production once to copy up the data so that the date sort works properly without having to rerun all servers.
