### PR TITLE
Add mechanism to restart testruns that appear to have crashed.

### DIFF
--- a/app/jobs/run_tests_job.rb
+++ b/app/jobs/run_tests_job.rb
@@ -9,6 +9,7 @@ class RunTestsJob < ActiveJob::Base
     begin
       testrun.execute()
     rescue => exception
+      Delayed::Worker.logger.error 'Testrun raised a critical error.  Attempting to save testrun as an error.'
       Delayed::Worker.logger.error exception
       testrun.status = 'error'
       testrun.save

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -26,7 +26,7 @@ class TestRun
   def execute()
 
     # tracks if another worker picks up this thread due to long execution time (but not crash)
-    this_worker_id = rand(1000000).to_s
+    this_worker_id = SecureRandom.uuid
 
     return false unless ['pending', 'stalled'].include?(self.status)
     recovered_from_stall = self.status == 'stalled'

--- a/lib/tasks/crucible.rake
+++ b/lib/tasks/crucible.rake
@@ -58,6 +58,20 @@ namespace :crucible do
 
   end
 
+  desc "identify stalled tasks and rerun"
+  task :restart_stalled_runs => [:environment] do
+
+    TestRun.where(:status=> 'running', :last_updated.lte => 10.minutes.ago).each do |test_run|
+
+      test_run.status = 'stalled'
+      test_run.save
+
+      RunTestsJob.perform_later(test_run.id.to_s)
+      
+    end
+
+  end
+
   desc "back fill blank names"
   task :guess_server_names => [:environment] do
     Server.all.select {|s| s.name.blank?}.each {|s| s.guess_name}


### PR DESCRIPTION
Prevoius attempts at preventing delayed job worker crashes have failed.  So it's time we have the system be able to recover from these crashes.

A cron job will run a rake task that looks for any unresponsive runs (no suites completed in last 10 minutes).  It marks it as stalled, and then starts another job to pick it up.

That job picks up where the last run left off (ignoring previously finished suites), and it marks the suite that the previous worker got stuck on as an Error.  It also adds an identifier to the test run to indicate that it now owns the test run, so if the previous run didn't actually die (but rather just got stuck for a really long time), that run will quit without continuing any further.