### PR TITLE
Only run supported tests on nightlies.

### DIFF
--- a/lib/tasks/crucible.rake
+++ b/lib/tasks/crucible.rake
@@ -44,12 +44,19 @@ namespace :crucible do
     servers.each_with_index do |s, i|
 
       if TestRun.where(:server => s, :status.in => ['pending', 'running']).length == 0
-        puts "\tStarting Server #{i+1} of #{servers.length}"
 
-        test_run = TestRun.new({server: s, date: Time.now, nightly: true})
-        test_run.add_tests(Test.where({multiserver: false}).sort {|l,r| l.name <=> r.name})
-        test_run.save!
-        RunTestsJob.perform_later(test_run.id.to_s)
+        tests = Test.where({multiserver: false}).sort {|l,r| l.name <=> r.name}
+        tests.select! { |t| s.supported_suites.include? t.id }
+
+        if tests.length > 0
+          test_run = TestRun.new({server: s, date: Time.now, nightly: true, supported_only: true})
+          test_run.add_tests(tests)
+          test_run.save!
+          RunTestsJob.perform_later(test_run.id.to_s)
+          puts "\tStarted Testing Server #{i+1} of #{servers.length}"
+        else
+          puts "\tNo supported test suites for server #{s.id}"
+        end
       else
         puts "\tServer #{i+1} of #{servers.length} is already under test"
       end


### PR DESCRIPTION
Filtered out any suite that isn't supported by the server in the nightly run.  Also added the 'supported_only' flag to the TestRun which should only run the supported tests within the suites.

One small issue is that this uses the cached conformance, which could technically be old.  When the run gets picked up the conformance will be updated and saved at that time, but it might run different suites than necessary since at that point the suites are locked in for that run.  I don't see this as a big issue though.

See #207 