### PR TITLE
Strongly prefer one FHIR sequence (STU3 now) on server.

### DIFF
--- a/app/assets/javascripts/views/templates/servers/conformance.hbs
+++ b/app/assets/javascripts/views/templates/servers/conformance.hbs
@@ -2,14 +2,14 @@
   <!-- METADATA CONTAINER -->
   <div class="row screen-changer">
     <div class="col-sm-12">
-      <span class="resources-changer active"><a>Conformance Resource Support</a></span>
-      <span class="metadata-changer"><a>Conformance Metadata</a></span>
+      <span class="resources-changer active"><a>Capability Statement Resource Support</a></span>
+      <span class="metadata-changer"><a>Capability Statement Metadata</a></span>
     </div>
   </div>
   <div class="row conformance metadata conformance-metadata hide">
     <div class="metadata-selector col-sm-3">
       <ul class="nav nav-pills nav-stacked metadata">
-        <li class="active"><a data-toggle="tab" href="#conformance_metadata">Conformance Metadata</a></li>
+        <li class="active"><a data-toggle="tab" href="#conformance_metadata">Capability Statement Metadata</a></li>
         <li><a data-toggle="tab" href="#rest-metadata">REST Metadata</a></li>
         <li><a data-toggle="tab" href="#document-metadata">Document Metadata</a></li>
         <li><a data-toggle="tab" href="#messaging-metadata">Messaging Metadata</a></li>

--- a/app/assets/stylesheets/_server.scss
+++ b/app/assets/stylesheets/_server.scss
@@ -100,7 +100,7 @@
 
 .server-test-details{
   text-align: left;
-  margin-bottom: 30px;
+  margin-bottom: 10px;
 }
 
 .server-url-panel {

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,13 +4,13 @@ class HomeController < ApplicationController
   def index
     #@servers = Server.all.order_by("percent_passing"=>:desc)
     # show all until issue is resolved
-    @servers = Server.where({percent_passing: {"$gte" => 0}}).order_by("percent_passing"=>:desc)
+    @servers = Server.where({percent_passing: {"$gte" => 0}, fhir_sequence: Rails.application.config.fhir_sequence}).order_by("percent_passing"=>:desc)
   end
 
   def server_scrollbar_data
 
     total_tests = Test.all.inject([]) { |a,i| a.concat i.methods}.count
-    servers = Server.where({percent_passing: {"$gte" => 0}}).map do |server|
+    servers = Server.where({percent_passing: {"$gte" => 0}, fhir_sequence: Rails.application.config.fhir_sequence}).map do |server|
       {
         id: server._id.to_s,
         name: server.name,

--- a/app/views/components/_server_summary_carousel.html.erb
+++ b/app/views/components/_server_summary_carousel.html.erb
@@ -65,9 +65,7 @@
           </div>
         <% end %>
       </div>
-      <% if servers.count > 15 %>
-        <div class="server-scroller"></div>
-      <% end %>
+      <div class="server-scroller"></div>
     </div>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -29,7 +29,7 @@
   <div class="service-list-row row">
     <div class="service-list-item">
       <h2>Test FHIR Conformance</h2>
-      Crucible provides a comprehensive testing capability for STU 3 v1.6.
+      Crucible provides a comprehensive testing capability for <strong><%= Rails.application.config.fhir_sequence %> v<%= Rails.application.config.fhir_version %></strong>.
       To get started, enter a publically accessible URL in the form below.
 
     </div>

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -54,8 +54,15 @@
                   </div>
                 </form>
               </div>
-
             </div>
+            <% if @server.fhir_sequence != Rails.application.config.fhir_sequence %>
+              <div class="alert alert-warning alert-dismissible" role="alert">
+                This version of Crucible tests FHIR <%= Rails.application.config.fhir_sequence %> (v<%= Rails.application.config.fhir_version %>).  This server does not currently
+                appear to support this version.  If this is not correct, please update the capability statement for this 
+                server and click Refresh in the Capability Statement tab below.
+                If you would like to test your server against DSTU2, please visit <a href="https://beta.projectcrucible.org">the DSTU2 version of Crucible</a>.
+              </div>
+            <% end %>
             <!-- END: server name and url -->
           </div>
         </div>
@@ -70,7 +77,7 @@
           <ul class="nav nav-tabs tabbed-data-container">
               <li class="tabbed-data test-run-summary-handle<%unless @server.summary_id.nil? %> active <%end%>" <%if @server.summary_id.nil? %>style="display:none"<%end%>><a data-toggle="tab" href="#test-run-summary-data" aria-expanded="true">Server Summary</a></li>
               <li class="tabbed-data<%if @server.summary_id.nil? %> active<%end%>"><a data-toggle="tab" href="#test-data" aria-expanded="false">Tests</a></li>
-            <li class="tabbed-data"><a data-toggle="tab" href="#conformance-data" aria-expanded="false"><i class="fa fa-lg fa-fw fa-spinner fa-pulse" id="conformance_spinner"></i>Conformance</a></li>
+            <li class="tabbed-data"><a data-toggle="tab" href="#conformance-data" aria-expanded="false"><i class="fa fa-lg fa-fw fa-spinner fa-pulse" id="conformance_spinner"></i>Capability Statement</a></li>
           </ul>
         </div>
         <div class="row">

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,11 @@ module Crucible
     # true: only allow requests to 443, 80, 8080
     config.restrict_test_ports = false
 
+    # Configuration to show which version of crucible is the most recent and is being tested on this server
+    config.fhir_sequence = 'STU3'
+    config.fhir_version = '1.8.0'
+    config.fhir_version_name = 'FHIR STU3 Candidate + Connectathon 14 (San Antonio)'
+
     # Configuration to determine if localhost servers and servers referencing localhost IP addresses are allowed (127.0.0.1)
     # false: allows localhost urls
     # true: rejects localhost urls to either localhost or localhost IP addresses

--- a/lib/tasks/crucible.rake
+++ b/lib/tasks/crucible.rake
@@ -39,7 +39,7 @@ namespace :crucible do
     # currently we exclude servers tagged argonaut from the nightly run
     excluded_tags = ['argonaut']
 
-    servers = Server.all.select {|s| (s.tags & excluded_tags).empty?}.sort {|l,r| (r.percent_passing||0) <=> (l.percent_passing||0)}
+    servers = Server.all.select {|s| (s.tags & excluded_tags).empty? and Rails.application.config.fhir_sequence == s.fhir_sequence}.sort {|l,r| (r.percent_passing||0) <=> (l.percent_passing||0)}
 
     servers.each_with_index do |s, i|
 
@@ -143,6 +143,16 @@ namespace :crucible do
       server.save
     end
 
+  end
+
+  desc "Update servers with version information stored in their conformance statement"
+  task :update_version_information => [:environment] do 
+    Server.each do |server|
+      # server.load_conformance
+      server.extract_version_from_conformance
+      print "#{server.name} (#{server.url}): #{server.fhir_sequence} | #{server.fhir_version}\n"
+
+    end
   end
 
 end


### PR DESCRIPTION
In the config you specify sequence (STU3).  When you load a conformance it attempts to guess sequence.  It will only show servers on the front page where the sequence is equal to what is specified in the config file (though we probably should move this to the models that this version of crucible is sourcing eventually).  I put in hooks for versions (e.g. 1.8.0), but for now this only really pays attention to sequence.  You can still run tests against DSTU2 servers, but there is a warning message above:

![screen shot 2017-01-09 at 8 53 18 pm](https://cloud.githubusercontent.com/assets/412901/21791434/b3b5bf76-d6b0-11e6-8559-25f636f2de3e.png)
