### PR TITLE
Add hidden server functionality.

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,13 +4,13 @@ class HomeController < ApplicationController
   def index
     #@servers = Server.all.order_by("percent_passing"=>:desc)
     # show all until issue is resolved
-    @servers = Server.where({percent_passing: {"$gte" => 0}, fhir_sequence: Rails.application.config.fhir_sequence}).order_by("percent_passing"=>:desc)
+    @servers = Server.where({percent_passing: {"$gte" => 0}, fhir_sequence: Rails.application.config.fhir_sequence, hidden: {"$ne" => true}}).order_by("percent_passing"=>:desc)
   end
 
   def server_scrollbar_data
 
     total_tests = Test.all.inject([]) { |a,i| a.concat i.methods}.count
-    servers = Server.where({percent_passing: {"$gte" => 0}, fhir_sequence: Rails.application.config.fhir_sequence}).map do |server|
+    servers = Server.where({percent_passing: {"$gte" => 0}, fhir_sequence: Rails.application.config.fhir_sequence, hidden: {"$ne" => true}}).map do |server|
       {
         id: server._id.to_s,
         name: server.name,

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -12,7 +12,7 @@ class ServersController < ApplicationController
   def create
     url = PostRank::URI.normalize(params['server']['url']).to_s
     url = url.chop if url[-1] == '/'
-    server = Server.where(url: url).first
+    server = Server.where(url: url).order_by("hidden" => :asc).first
     unless server
       server = Server.new(params.require(:server).permit(:name))
       server.url = url

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -27,6 +27,7 @@ class Server
   field :last_run_at, type: Time
   field :fhir_sequence, type: String
   field :fhir_version, type: String
+  field :hidden, type: Boolean, default: false
 
   def get_default_scopes
     [{ name: 'launch', description: 'Simulate an EHR launch profile', elem_id: 'launch_check' },


### PR DESCRIPTION
This adds a hidden flag functionality to the server.  It won't show up on the front page if hidden.  If you have the direct url you can still get to it.  I also added rake tools to help me best identify which servers we should hide.

If a given url has hidden and non-hidden server_ids, it will pick the non-hidden server if you are entering the url via the front page command line.