### PR TITLE
Add links to smart on fhir app and message about v.1.8.0.

### DIFF
--- a/app/assets/stylesheets/_components.scss
+++ b/app/assets/stylesheets/_components.scss
@@ -1,7 +1,7 @@
 .container{
   min-width: 1200px;
   &.main {
-    margin-top: 50px;
+    margin-top: 30px;
     margin-bottom: 50px;
   }
   &.servers-show {

--- a/app/assets/stylesheets/_home.scss
+++ b/app/assets/stylesheets/_home.scss
@@ -25,18 +25,19 @@
   margin-left: 0;
   .service-list-item {
     float: left;
-    width: 32%;
+    width: 23%;
     margin-right: 20px;
     color: #666;
     background-color: #d7d5d5;
     border: 5px solid #fff;
     border-radius: 10px;
     padding: 10px 15px;
-    height: 185px;
+    height: 220px;
 
     h2 {
       color: #666;
       margin-top: 10px;
+      font-size: 1.1em;
     }
   }
   :last-child {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,7 +12,7 @@
     <img class="pull-right" src="/assets/logo.png"/>
     <h1>Open Source FHIR Testing</h1> 
     <p>
-    Crucible is a set of <a href="http://github.com/fhir-crucible/crucible">open source</a> testing tools for HL7<sup>®</sup> FHIR<sup>®</sup>.
+    Crucible is a suite of <a href="http://github.com/fhir-crucible">open source</a> testing tools for HL7<sup>®</sup> FHIR<sup>®</sup>.
     It is provided as a free service to the FHIR development community to help promote correct FHIR implementations.  It currently can test
     for conformance to the FHIR standard, score patient records for completeness, and generate synthetic patient data.
     </p>
@@ -20,7 +20,6 @@
     <p>
     We are actively seeking contributors.  Visit our <a href="https://github.com/fhir-crucible/crucible">github page</a> for more information.
     </p>
-
   </div>
 </div>
 
@@ -42,10 +41,20 @@
       <h2>Generate FHIR Test Data</h2>
       Load <a href="/testdata">synthetic test data</a> to your server with Crucible and Synthea!
     </div>
+    <div class="service-list-item">
+      <h2>SMART on FHIR App</h2>
+      Test your SMART on FHIR implementation using a Crucible <a href="/smart">app</a>.
+    </div>
   </div>
 </div>
 
 <div class="container main">
+
+  <div class="alert alert-warning alert-dismissible" role="alert">
+    Crucible has been updated to FHIR STU3 v1.8.0 in preparation for the San Antonio Connectathon.  You may also now test your SMART on FHIR 
+    implementation using the <a href="/smart">Crucible SMART on FHIR app</a>.
+  </div>
+
 
   <form action="/servers" method="post" id="new-server-form">
     <!--     <div class="banner row">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,8 @@
             <li><a href="/" class="navButton">Server Test</a></li>
             <li><a href="/scorecard" class="navButton">Scorecard</a></li>
             <li><a href="/testdata" class="navButton">Test Data</a></li>
-            <li><a href="https://beta.projectcrucible.org" class="navButton">Previous Version</a></li>
+            <li><a href="/smart" class="navButton">SMART on FHIR</a></li>
+            <li><a href="https://beta.projectcrucible.org" class="navButton">DSTU2 Version</a></li>
             <li class="dropdown">
               <a href="#" class="navButton" data-toggle="dropdown" id="contact-drop" role="button" aria-haspopup="true" aria-expanded="false">Contact Us<span class="caret"></span></a>
               <ul class="dropdown-menu" aria-labelledby="contact-drop">


### PR DESCRIPTION
I have links point to projectcrucible.org/smart.  I will update as necessary depending on how @okeefm deploys.  Let me know if this is sufficient marketing for the app and the changes we made.

![screen shot 2017-01-12 at 12 39 16 pm](https://cloud.githubusercontent.com/assets/412901/21901339/4c1b6c82-d8c5-11e6-87b4-28168af5f4f5.png)
