### PR TITLE
Fix permalink, which has been broken since test groups introduced.

### DIFF
--- a/app/assets/javascripts/views/component/test-executor.coffee
+++ b/app/assets/javascripts/views/component/test-executor.coffee
@@ -45,6 +45,7 @@ class Crucible.TestExecutor
     @progress = $("##{@element.data('progress')}")
     @registerHandlers()
     @defaultSelection = @parseDefaultSelection(window.location.hash)
+    $('#test-data-tab').trigger('click') if @defaultSelection
     @loadTests()
     @element.find('.filter-by-executed').css('display', 'none')
     @element.find('.filter-by-failures').css('display', 'none')
@@ -98,7 +99,8 @@ class Crucible.TestExecutor
       @continueTestRun() if @runningTestRunId && !@defaultSelection
       @filter(supported: true)
       @renderPastTestRunsSelector({text: 'Select past test run', value: '', disabled: true, selected: true})
-    ).complete(() -> $('.test-result-loading').hide())
+      $('.test-result-loading').hide() if !@defaultSelection
+    )
 
   renderSuites: =>
     @element.find('.test-results .button-holder').removeClass('hide')
@@ -190,7 +192,7 @@ class Crucible.TestExecutor
         @handleSuiteResult(@suitesById[suiteId], {tests: result.result}, suiteElement) if @suitesById[suiteId]
       if @defaultSelection
         @element.find("#test-#{@defaultSelection.suiteId} a.collapsed").click()
-        @element.find("#test-#{@defaultSelection.suiteId} ##{@defaultSelection.testId}").click()
+        @element.find("#test-#{@defaultSelection.suiteId} ##{@defaultSelection.testId}").click().closest(".suite-group").children('a').trigger('click')
         @defaultSelection = null #prevent from auto-navigation from default selection any more
       @filter(supported: data.test_run.supported_only)
       @filter(executed: true, supported: (if data.test_run.supported_only then true else false))

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -76,7 +76,7 @@
         <div class="row">
           <ul class="nav nav-tabs tabbed-data-container">
               <li class="tabbed-data test-run-summary-handle<%unless @server.summary_id.nil? %> active <%end%>" <%if @server.summary_id.nil? %>style="display:none"<%end%>><a data-toggle="tab" href="#test-run-summary-data" aria-expanded="true">Server Summary</a></li>
-              <li class="tabbed-data<%if @server.summary_id.nil? %> active<%end%>"><a data-toggle="tab" href="#test-data" aria-expanded="false">Tests</a></li>
+              <li class="tabbed-data<%if @server.summary_id.nil? %> active<%end%>"><a data-toggle="tab" href="#test-data" id="test-data-tab" aria-expanded="false">Tests</a></li>
             <li class="tabbed-data"><a data-toggle="tab" href="#conformance-data" aria-expanded="false"><i class="fa fa-lg fa-fw fa-spinner fa-pulse" id="conformance_spinner"></i>Capability Statement</a></li>
           </ul>
         </div>


### PR DESCRIPTION
Clicking 'Test Run Permalink' in the results of a test should now give you a link, that when opened in a fresh browser/tab will automatically open the Tests tab, the correct test category, the test suite, and the individual test.  This has been broken since we introduced test groups, and was made even more broken when we changed the order of the server tabs.