### PR TITLE
Fix url normalize dstu2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'bcp47'
 gem 'nokogiri-diff'
 gem 'addressable'
 gem 'handlebars_assets'
-gem 'postrank-uri'
 gem 'oauth2'
 gem 'ruby-progressbar'
 gem "non-stupid-digest-assets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/fhir-crucible/fhir_client.git
-  revision: 110d1df427c88a9c5568307ce62f24e17a4f9415
+  revision: ed820a727505c1143cccc05ce1495f8219eac10a
   branch: dstu2
   specs:
     fhir_client (1.0.0)
@@ -68,7 +68,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     ansi (1.5.0)
     arel (6.0.3)
     autoprefixer-rails (3.1.0.20140911)
@@ -163,7 +164,7 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.6.2)
-    mini_portile (0.5.3)
+    mini_portile2 (2.1.0)
     minitest (5.8.1)
     minitest-reporters (1.0.5)
       ansi
@@ -190,8 +191,8 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.2.0)
-    nokogiri (1.6.3)
-      mini_portile (~> 0.5.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     nokogiri-diff (0.2.0)
       nokogiri (~> 1.5)
       tdiff (~> 0.3, >= 0.3.2)
@@ -208,10 +209,6 @@ GEM
     optionable (0.2.0)
     origin (2.1.1)
     orm_adapter (0.5.0)
-    postrank-uri (1.0.18)
-      addressable (~> 2.3.0)
-      nokogiri (~> 1.6.1)
-      public_suffix (~> 1.1.3)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -219,7 +216,7 @@ GEM
     pry-byebug (2.0.0)
       byebug (~> 3.4)
       pry (~> 0.10)
-    public_suffix (1.1.3)
+    public_suffix (2.0.5)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -335,7 +332,6 @@ DEPENDENCIES
   non-stupid-digest-assets
   oauth2
   plan_executor!
-  postrank-uri
   pry
   pry-byebug
   rails (= 4.2.4)

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -10,7 +10,7 @@ class ServersController < ApplicationController
   end
 
   def create
-    url = PostRank::URI.normalize(params['server']['url']).to_s
+    url = Addressable::URI.parse(params['server']['url']).normalize.to_s
     url = url.chop if url[-1] == '/'
     server = Server.where(url: url).first
     unless server

--- a/lib/tasks/crucible.rake
+++ b/lib/tasks/crucible.rake
@@ -62,7 +62,7 @@ namespace :crucible do
     servers_by_url = {}
 
     servers.each do |server|
-      url = PostRank::URI.normalize(server.url).to_s
+      url = Addressable::URI.parse(server.url).normalize.to_s
       url = url.chop if url[-1] == '/'
       servers_by_url[url] ||= []
       servers_by_url[url] << server


### PR DESCRIPTION
Crucible was using a gem called PostRank, which had a dependency on a an old version of gem called 'addressable', which we used in plan_executor.  Plan executor used that old version, which doesn't properly encode '+'.  I removed the reference to PostRank and updated crucible to use addressable directly, so it could pull in a newer version and wouldn't break plan_executor.