### PR TITLE
Remove PostRank gem, which had a dependency messing up encoding.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ gem 'bcp47'
 gem 'nokogiri-diff'
 gem 'addressable'
 gem 'handlebars_assets'
-gem 'postrank-uri'
 gem 'oauth2'
 gem 'ruby-progressbar'
 gem "non-stupid-digest-assets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,10 +254,6 @@ GEM
     origin (2.1.1)
     orm_adapter (0.5.0)
     pickup (0.0.11)
-    postrank-uri (1.0.18)
-      addressable (~> 2.3.0)
-      nokogiri (~> 1.6.1)
-      public_suffix (~> 1.1.3)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -265,7 +261,6 @@ GEM
     pry-byebug (2.0.0)
       byebug (~> 3.4)
       pry (~> 0.10)
-    public_suffix (1.1.3)
     rack (1.6.5)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -387,7 +382,6 @@ DEPENDENCIES
   non-stupid-digest-assets
   oauth2
   plan_executor!
-  postrank-uri
   pry
   pry-byebug
   rails (= 4.2.4)

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -10,7 +10,7 @@ class ServersController < ApplicationController
   end
 
   def create
-    url = PostRank::URI.normalize(params['server']['url']).to_s
+    url = Addressable::URI.parse(params['server']['url']).normalize.to_s
     url = url.chop if url[-1] == '/'
     server = Server.where(url: url).order_by("hidden" => :asc).first
     unless server

--- a/lib/tasks/crucible.rake
+++ b/lib/tasks/crucible.rake
@@ -90,7 +90,7 @@ namespace :crucible do
     servers_by_url = {}
 
     servers.each do |server|
-      url = PostRank::URI.normalize(server.url).to_s
+      url = Addressable::URI.parse(server.url).normalize.to_s
       url = url.chop if url[-1] == '/'
       servers_by_url[url] ||= []
       servers_by_url[url] << server


### PR DESCRIPTION
Fixes url encoding for stu3 version of crucible.  Basically this PR (and the DSTU2 PR) makes crucible work like standalone plan_executor.