### PR TITLE
Smarter about how version mismatches are handled.

### DIFF
--- a/app/assets/javascripts/views/component/conformance.coffee
+++ b/app/assets/javascripts/views/component/conformance.coffee
@@ -9,8 +9,10 @@ class Crucible.Conformance
 
   constructor: ->
     @element = $('#conformance-data')
+    @mismatch_alert_element = $('#fhir-sequence-mismatch')
     return unless @element.length
     @template = HandlebarsTemplates['views/templates/servers/conformance']
+    @version_mismatch_template = HandlebarsTemplates['views/templates/servers/partials/fhir_version_notification']
     @serverId = @element.data('server-id')
     @loadConformance()
 
@@ -21,6 +23,10 @@ class Crucible.Conformance
       .success ((data) =>
         @updateConformance(data)
         @removeConformanceSpinner()
+        @mismatch_alert_element.hide()
+        if data.fhir_sequence != data.crucible_fhir_sequence
+          @mismatch_alert_element.html(@version_mismatch_template(data))
+          @mismatch_alert_element.show()
         @element.trigger('conformanceInitialized') if data.conformance.updated
         @registerHandlers()
       )

--- a/app/assets/javascripts/views/templates/servers/partials/fhir_version_notification.hbs
+++ b/app/assets/javascripts/views/templates/servers/partials/fhir_version_notification.hbs
@@ -1,0 +1,4 @@
+This version of Crucible tests FHIR {{crucible_fhir_sequence}} (version {{crucible_fhir_version}}).  This server does not currently
+appear to support this version as it is reporting version "{{fhir_version}}" in its capability statement.
+If this is not correct, please update the capability statement for this server and click Refresh in the Capability Statement tab below.
+If you would like to test your server against DSTU2, please visit <a href="https://beta.projectcrucible.org">the DSTU2 version of Crucible</a>.

--- a/app/assets/stylesheets/_conformance.scss
+++ b/app/assets/stylesheets/_conformance.scss
@@ -60,3 +60,8 @@
     }
   }
 }
+
+#fhir-sequence-mismatch {
+  display:none; // hidden by default
+  clear: both;
+}

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -84,7 +84,15 @@ class ServersController < ApplicationController
 
   def conformance
     server = Server.find(params[:server_id])
-    render json: {conformance: server.load_conformance(params[:refresh])}
+    conformance = server.load_conformance(params[:refresh])
+
+    render json: {
+      conformance: conformance,
+      crucible_fhir_version: Rails.application.config.fhir_version,
+      crucible_fhir_sequence: Rails.application.config.fhir_sequence,
+      fhir_version: server.fhir_version,
+      fhir_sequence: server.fhir_sequence,
+    }
   end
 
   def summary

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -2,30 +2,30 @@
   <div class="row content">
     <div class="col-sm-12">
       <div class="palette report">
-          <% if flash[:notice] %>
-            <div class="alert alert-success alert-dismissible" role="alert">
-              <%= flash[:notice] %>
-              <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            </div>
-          <% end %>
-          <% if flash[:alert] %>
-            <div class="alert alert-danger alert-dismissible" role="alert">
-              <%= flash[:alert] %>
-              <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            </div>
-          <% end %>
+        <% if flash[:notice] %>
+          <div class="alert alert-success alert-dismissible" role="alert">
+            <%= flash[:notice] %>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          </div>
+        <% end %>
+        <% if flash[:alert] %>
+          <div class="alert alert-danger alert-dismissible" role="alert">
+            <%= flash[:alert] %>
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+          </div>
+        <% end %>
         <div class="row">
           <div class="col-sm-12 server-test-details">
             <!-- START: server name and url -->
             <div class="server-details" data-server-id="<%=@server.id%>">
               <div class="authorize-icon pull-left">
-                  <a data-toggle="modal" 
-                      data-target="#authorize-modal" 
-                      class="authorization-handle hidden" 
-                      href="#" 
-                      data-oauth-refresh-token="<%= @server.try(:oauth_token_opts) && @server.oauth_token_opts['refresh_token'] %>"
-                      data-oauth-client-Id="<%= @server.try(:client_id) %>"
-                      data-oauth-expires-at="<%= @server.try(:oauth_token_opts) && @server.oauth_token_opts['expires_at'] %>"><i class="fa fa-lock"></i></a>
+                <a data-toggle="modal" 
+                   data-target="#authorize-modal" 
+                   class="authorization-handle hidden" 
+                   href="#" 
+                   data-oauth-refresh-token="<%= @server.try(:oauth_token_opts) && @server.oauth_token_opts['refresh_token'] %>"
+                   data-oauth-client-Id="<%= @server.try(:client_id) %>"
+                   data-oauth-expires-at="<%= @server.try(:oauth_token_opts) && @server.oauth_token_opts['expires_at'] %>"><i class="fa fa-lock"></i></a>
               </div>
               <div class="server-url-name pull-left">
                 <div class="server-name-panel emphasize editToggle" data-toggle="tooltip" data-placement="bottom" title="<%= @server.name %>">
@@ -35,7 +35,7 @@
                   <a target="_blank" class="server-url-label" href="<%= @server.url %>"><%= @server.url %></a>
                 </div>
                 <div class="server-tags-panel emphasize editToggle">
-                    <div class="server-tags-label"></div>
+                  <div class="server-tags-label"></div>
                 </div>
               </div>
               <a class="edit-server-name-icon editToggle pull-left"><i class="fa fa-pencil-square-o edit-server-name"></i></a>
@@ -55,8 +55,9 @@
                 </form>
               </div>
             </div>
-          <div class="alert alert-warning alert-dismissible" id="fhir-sequence-mismatch" role="alert"></div>
-            <!-- END: server name and url -->
+            <div class="alert alert-warning alert-dismissible" id="fhir-sequence-mismatch" role="alert"></div>
+          </div>
+          <!-- END: server name and url -->
         </div>
         <div class="row collapse">
           <div class="progress" id="execution-progress">
@@ -67,8 +68,8 @@
         </div>
         <div class="row">
           <ul class="nav nav-tabs tabbed-data-container">
-              <li class="tabbed-data test-run-summary-handle<%unless @server.summary_id.nil? %> active <%end%>" <%if @server.summary_id.nil? %>style="display:none"<%end%>><a data-toggle="tab" href="#test-run-summary-data" aria-expanded="true">Server Summary</a></li>
-              <li class="tabbed-data<%if @server.summary_id.nil? %> active<%end%>"><a data-toggle="tab" href="#test-data" id="test-data-tab" aria-expanded="false">Tests</a></li>
+            <li class="tabbed-data test-run-summary-handle<%unless @server.summary_id.nil? %> active <%end%>" <%if @server.summary_id.nil? %>style="display:none"<%end%>><a data-toggle="tab" href="#test-run-summary-data" aria-expanded="true">Server Summary</a></li>
+            <li class="tabbed-data<%if @server.summary_id.nil? %> active<%end%>"><a data-toggle="tab" href="#test-data" id="test-data-tab" aria-expanded="false">Tests</a></li>
             <li class="tabbed-data"><a data-toggle="tab" href="#conformance-data" aria-expanded="false"><i class="fa fa-lg fa-fw fa-spinner fa-pulse" id="conformance_spinner"></i>Capability Statement</a></li>
           </ul>
         </div>
@@ -139,7 +140,7 @@
                       </div>
                       <div class="col-sm-3 col-sm-offset-9">
                         <button class="btn cancel" data-toggle="modal" data-target="#cancel-modal" style="display:none">
-                            Cancel
+                          Cancel
                         </button>
                       </div>
                     </div>
@@ -180,7 +181,7 @@
     </div>
   </div>
 
- <!-- Modal Response Data-->
+  <!-- Modal Response Data-->
   <div class="modal fade" id="data-modal" tabindex="-1" role="dialog" aria-labelledby="Data for test result">
     <div class="modal-dialog" role="document">
       <div class="modal-content">

--- a/app/views/servers/show.html.erb
+++ b/app/views/servers/show.html.erb
@@ -55,16 +55,8 @@
                 </form>
               </div>
             </div>
-            <% if @server.fhir_sequence != Rails.application.config.fhir_sequence %>
-              <div class="alert alert-warning alert-dismissible" role="alert">
-                This version of Crucible tests FHIR <%= Rails.application.config.fhir_sequence %> (v<%= Rails.application.config.fhir_version %>).  This server does not currently
-                appear to support this version.  If this is not correct, please update the capability statement for this 
-                server and click Refresh in the Capability Statement tab below.
-                If you would like to test your server against DSTU2, please visit <a href="https://beta.projectcrucible.org">the DSTU2 version of Crucible</a>.
-              </div>
-            <% end %>
+          <div class="alert alert-warning alert-dismissible" id="fhir-sequence-mismatch" role="alert"></div>
             <!-- END: server name and url -->
-          </div>
         </div>
         <div class="row collapse">
           <div class="progress" id="execution-progress">


### PR DESCRIPTION
When a server's capability statement is now loaded (in any situation: first time server created, when server page revisited and already has conformance, or when do conformance refresh), it checks the version crucible supports and puts up a notification on the top telling you if there is a potential version mismatch.

Before, this was only done when the server page (through rails) was loaded and there already was a conformance cached in the system.  If there wasn't a conformance cached, it always said there was a version mismatch.  This was a problem because when you first created a server it always though there was a version mismatch, which is very misleading.

![screen shot 2017-03-20 at 3 38 58 pm](https://cloud.githubusercontent.com/assets/412901/24118230/68e5cbda-0d83-11e7-990d-c06d9581e5a4.png)
