### PR TITLE
Cache doppler history for faster server page load.

### DIFF
--- a/app/assets/javascripts/views/component/doppler.coffee
+++ b/app/assets/javascripts/views/component/doppler.coffee
@@ -225,14 +225,14 @@ class Crucible.Doppler
       .append("rect")
       .attr("width", cellSize)
       .attr("height", cellSize)
-      .attr("x", (d) -> margin_left + (52 - weekdiff(format.parse(d.date), next_sunday)) * (3 + cellSize))
+      .attr("x", (d) -> margin_left + (51 - weekdiff(format.parse(d.date), next_sunday)) * (3 + cellSize))
       .attr("y", (d) -> margin_top + (d.index+1) * cellSize)
       .style("fill", (d) -> color(d.value, threshold))
       .style("stroke", "#ccc")
       .on('mouseover', tip.show)
       .on('mouseout', tip.hide)
       .on("click", (d) =>
-        index = weekdiff(format.parse(d.date), next_sunday) - 1
+        index = weekdiff(format.parse(d.date), next_sunday)
         if @data.length > 52
           index = index + 1
         switchDate(index)

--- a/app/assets/javascripts/views/component/doppler.coffee
+++ b/app/assets/javascripts/views/component/doppler.coffee
@@ -66,7 +66,7 @@ class Crucible.Doppler
     margin_top = 50
     cellSize = 14
     threshold = .65
-    format = d3.time.format("%Y-%m-%d")
+    format = d3.time.format("%Y-%m-%dT%H:%M:%S.%LZ")
     today = new Date()
     next_sunday = (new Date()).setDate(today.getDate() + (7-today.getDay()))
     monthNames =  [today.getFullYear(),'Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']

--- a/app/assets/javascripts/views/component/test-executor.coffee
+++ b/app/assets/javascripts/views/component/test-executor.coffee
@@ -398,7 +398,7 @@ class Crucible.TestExecutor
     $.get("/servers/#{@serverId}/test_runs/#{@runningTestRunId}").success((result) =>
       test_run = result.test_run
       percent_complete = test_run.test_results.length / test_run.test_ids.length
-      @progress.find('.progress-bar').css('width',"#{(Math.max(2, percent_complete * 100))}%")
+      @progress.find('.progress-bar').css('width',"#{(Math.min(98, Math.max(2, percent_complete * 100)))}%")
       if Object.keys(@processedResults).length < test_run.test_results.length
         for result in test_run.test_results
           suiteId = result.test_id

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -101,64 +101,25 @@ class ServersController < ApplicationController
   end
 
   def summary_history
-    summaries = Summary.where({server_id: params[:server_id]})
-    summary_tree = Crucible::FHIRStructure.get.deep_dup
-    
-    zeroize_summary(summary_tree)
+    server = Server.find(params[:server_id])
 
-    # Generate list of sundays
     sundays = (52.weeks.ago.to_date..Date.today).to_a.select {|k| k.wday == 0}
-
-    # Put sundays into a hash and use to only save one data point per week
-    sunday_index = sundays.inject({}) { |h,k| h[k] = nil; h}
-
-    sections = {} # store the sections that we come across
-
-    # loop through each summary and place in the sunday index
-    summaries.each_entry do |e|
-
-      # build the value for this run, which is a combination of the date and all the passed & total values for the categories
-      all_nodes = all_nodes(e.compliance) # save in all_nodes hash
-
-      all_nodes.keys.each { |k| sections[k] = { 'passed' => 0, 'total' => 0} }
-
-      new_tree = summary_tree.deep_dup
-      new_tree['date'] = e.generated_at.to_date
-
-      rebuild_summary(new_tree, all_nodes)
-
-      # if this is before our first sunday, and is after others stored in the first sunday, then have it register on the first sunday
-      if e.generated_at < sundays.first  and (sunday_index[sundays.first].nil? or sunday_index[sundays.first]['date'] < e.generated_at.to_date)
-        sunday_index[sundays.first] = new_tree 
-      end
-
-      #figure out the next sunday from this date
-      next_sunday = e.generated_at.to_date + (7 - e.generated_at.wday)
-
-      # store this on the next sunday, as long as nothing from later in the week is already stored there
-      # if before first sunday, don't store because we've already taken care of that
-      if next_sunday > sundays.first and (sunday_index[next_sunday].nil? or sunday_index[next_sunday]['date'] < e.generated_at.to_date)
-        sunday_index[next_sunday] = new_tree
-      end
+    server.history.reject! do |entry|
+      sundays.exclude?(entry["date"]) && entry["date"] < sundays.last
     end
 
-    # carry forward sundays with data to those without data
-    sundays.inject(nil) {|p, k| sunday_index[k] = sunday_index[k] || p }
-
-    # put the sunday_index into an array format for consumption by d3
-    result = sunday_index.values
-
-    # fix the dates on items to be on Sundays (since now it just stores the run date, not the date of the sunday)
-    # include dates and section names with null values if the date has no data (happens on dates before the first run)
-    sundays.each_with_index do |val, index| 
-      if (result[index])
-        result[index] = result[index].merge({'date'=>val})
-      else
-        result[index] = {'date' => val}.merge(summary_tree)
-      end
+    if server.history.length == 0
+      server.generate_history
     end
 
-    render json: result.to_json
+    sundays.reject! {|sunday| server.history.select{|entry| entry["date"] == sunday}.length > 0}
+
+    sundays.each do |sunday|
+      server.history << server.history.last
+      server.history.last['date'] = sunday
+    end
+
+    render json: server.history.to_json
   end
 
   def supported_tests
@@ -248,49 +209,4 @@ class ServersController < ApplicationController
     params.require(:server).permit(:url, :name, tags: [])
   end
 
-  def zeroize_summary(hash)
-    hash['total'] = hash['passed'] = 0
-    unless hash['children'].nil?
-      hash['children'].each { |c| zeroize_summary(c) }
-    end
-  end
-
-  def all_nodes(hash, ret = {})
-
-    ret[hash['name'].downcase] = {'passed' => hash['passed'], 'total' => hash['total']}
-    hash['children'].each { |c| all_nodes(c, ret) } unless hash['children'].nil?
-
-    ret
-
-  end
-
-  def rebuild_summary(template, keys)
-
-    # collect the name and any aliases together then see if any of them have a matching node in the results
-    all_names = [template['name']] + (template['aka'] || [])
-    matching_node = all_names.map {|name| keys[name.downcase]}.compact.first
-    if matching_node
-      template['total'] = matching_node['total']
-      template['passed'] = matching_node['passed']
-    else
-      template['total'] = template['passed'] = 0
-    end
-
-    template['children'].each { |c| rebuild_summary(c, keys) } unless template['children'].nil?
-
-    if template['total'] == 0 && template['children']
-      # back fill the parent if we are missing data from the children. This can happen when the structure changes.
-      patch_structure_change(template)
-    end
-
-  end
-
-  def patch_structure_change(template)
-    total = template['children'].reduce(0) {|sum, x| sum += x['total']}
-    if total > 0
-      passed = template['children'].reduce(0) {|sum, x| sum += x['passed']}
-      template['total'] = total
-      template['passed'] = passed
-    end
-  end
 end

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -148,7 +148,7 @@ class TestRun
     self.server.percent_passing = (compliance['passed'].to_f / ([compliance['total'].to_f || 0, 1].max)) * 100.0
     self.server.last_run_at = Time.now
     summary.save!
-    self.server.generate_history
+    self.server.update_history(summary)
     self.server.save!
 
     self.status = 'finished'

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -148,7 +148,7 @@ class TestRun
     self.server.percent_passing = (compliance['passed'].to_f / ([compliance['total'].to_f || 0, 1].max)) * 100.0
     self.server.last_run_at = Time.now
     summary.save!
-    self.server.generate_history()
+    self.server.generate_history
     self.server.save!
 
     self.status = 'finished'

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -148,6 +148,7 @@ class TestRun
     self.server.percent_passing = (compliance['passed'].to_f / ([compliance['total'].to_f || 0, 1].max)) * 100.0
     self.server.last_run_at = Time.now
     summary.save!
+    self.server.generate_history()
     self.server.save!
 
     self.status = 'finished'


### PR DESCRIPTION
This caches the history that is generated for a server and is shown in hte 'doppler' chart.  On my laptop, generating the history takes 20+ seconds because of all the data pulled out of mongo, which clogs up the server load page's ajax calls.  This data is pretty easily cached, and we are caching the summaries anyhow, so I figure saving the history in one hash in the database makes sense.  And it makes my experience a lot better when loading the server page, or refreshing it.

The one downside is now after I run a testrun, that 20 second delay now appears at the end of the test run but before it is marked as completely finished.  This might be annoying if you are trying to run a bunch of small test runs over and over.  So I'm not completely sold that this is the right approach.

Note: in production the delay is much smaller than 20 seconds... maybe more like 3 or 4.

So I'm not 100% convinced that we should merge this... any thoughts?