### PR TITLE
Caching tests in controller caused stale supported data.

### DIFF
--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -128,8 +128,7 @@ class ServersController < ApplicationController
 
   def supported_tests
     server = Server.find(params[:server_id])
-    @@suites ||= Test.where({multiserver: false}).sort {|l,r| l.name <=> r.name}
-    @suites = @@suites
+    @suites = Test.where({multiserver: false}).sort {|l,r| l.name <=> r.name}
 
     server.collect_supported_tests rescue logger.error "error collecting supported tests"
     if server.supported_suites


### PR DESCRIPTION
There was a strange bug where tests weren't being filtered properly based on whether or not it was supported.  Sometimes it worked, sometimes it didn't.  I believe I tracked it down to the use of a class level variable for caching the query for all tests.  By storing it in there, the reference was kept between requests, and marking tests as "supported" would break later servers that didn't support the test.

I suppose this was done for performance reasons, but having the controller be stateful between requests is asking for bugs (like this one), so I removed it.  We can check out performance when we deploy to make sure that it isn't a noticeable difference.