### PR TITLE
Add recent test runs list to make easier for new users to see runs.

### DIFF
--- a/app/assets/javascripts/views/component/server-summary.coffee
+++ b/app/assets/javascripts/views/component/server-summary.coffee
@@ -5,6 +5,7 @@ $(document).ready( ->
 class Crucible.ServerSummary
   templates:
     failures: 'views/templates/servers/failures_report'
+    recentRuns: 'views/templates/servers/recent_runs'
 
   constructor: ->
     @element = $('.test-run-report')
@@ -12,6 +13,7 @@ class Crucible.ServerSummary
     @serverId = @element.data('server-id')
     @registerHandlers()
     @failuresReportElement = @element.find('.common-failures')
+    @recentRunsReportElement = @element.find('.recent-runs')
     @loadAggregateRun()
 
   registerHandlers: =>
@@ -21,6 +23,18 @@ class Crucible.ServerSummary
       @renderHeader(@starburst.selectedNode)
       @loadHistory()
       false
+    )
+    $('.past-test-runs-selector').on('testRunsLoaded', (event) =>
+      pastRunsSelector = $('.past-test-runs-selector')
+      pastRuns = pastRunsSelector.data('testRuns').past_runs
+      pastRuns = pastRuns.slice(0,50) # only show most cent
+      @recentRunsReportElement.html(HandlebarsTemplates[@templates.recentRuns]({pastRuns: pastRuns}))
+      @recentRunsReportElement.find('.recent-runs-item').click( (event) ->
+        id = $(@).data('id')
+        $('.change-test-run').trigger('click')
+        pastRunsSelector.val(id).trigger('change')
+        $('#test-data-tab').trigger('click')
+      )
     )
 
   renderFailures: ->

--- a/app/assets/javascripts/views/component/test-executor.coffee
+++ b/app/assets/javascripts/views/component/test-executor.coffee
@@ -132,6 +132,7 @@ class Crucible.TestExecutor
       return unless data
       foundDefaultSelection = false
       selector = @element.find('.past-test-runs-selector')
+      selector.data('testRuns', data).trigger('testRunsLoaded')
       selector.empty()
       if elementToAdd
         option = $("<option>#{elementToAdd.text}</option>")

--- a/app/assets/javascripts/views/handlebars_helpers.coffee
+++ b/app/assets/javascripts/views/handlebars_helpers.coffee
@@ -64,3 +64,7 @@ Handlebars.registerHelper('supported-status-text', (resource, operation) ->
 Handlebars.registerHelper('percentage', (numerator, denominator) ->
   return "#{Math.round((numerator/denominator) * 100)}%"
 )
+
+Handlebars.registerHelper('format-date', (date) ->
+  return moment(date).format('MM/DD/YYYY HH:mm');
+)

--- a/app/assets/javascripts/views/templates/servers/failures_report.hbs
+++ b/app/assets/javascripts/views/templates/servers/failures_report.hbs
@@ -1,8 +1,8 @@
   <div class="failures-title">
-    <div class="pull-right">
-        <small>Most common {{count}} of {{total}} different failures.</small>
-      <!--<button class="btn secondary"><i class="fa fa-cog"></i> Tag Filters</button>-->
-    </div>
+    <!-- <div class="pull&#45;right"> -->
+    <!--     <small>Most common {{count}} of {{total}} different failures.</small> -->
+    <!--   <!&#45;&#45;<button class="btn secondary"><i class="fa fa&#45;cog"></i> Tag Filters</button>&#45;&#45;> -->
+    <!-- </div> -->
     Recent Common Failures
     <div class="tag-list">
       <!---->

--- a/app/assets/javascripts/views/templates/servers/recent_runs.hbs
+++ b/app/assets/javascripts/views/templates/servers/recent_runs.hbs
@@ -1,0 +1,18 @@
+<div class="recent-runs-title">
+  Recent Test Runs
+</div>
+<table class="recent-runs-container">
+  {{#each pastRuns as |run|}}
+    <tr class="recent-runs-item" data-id="{{run.id}}" title='{{#if run.supported_only}}(S) Only test server supported resources and operations.{{/if}} {{#if run.nightly}}(N) Automated nightly test run.{{/if}}'>
+      <td>
+      {{format-date run.date}} 
+      </td><td>
+      {{run.test_ids.length}} Suite{{pluralize? run.test_ids.length}}
+      </td><td>
+      </td><td>
+        {{#if run.supported_only}}S{{#if run.nightly}}, {{/if}}{{/if}}
+        {{#if run.nightly}}N{{/if}}
+        </td>
+      </tr>
+    {{/each}}
+</table>

--- a/app/assets/stylesheets/_widgets.scss
+++ b/app/assets/stylesheets/_widgets.scss
@@ -315,9 +315,39 @@
   }
 
   .common-failures {
+    border-right: 1px solid #ddd;
   }
 
   .test-failures {
     border-right: 1px solid #ddd;
   }
+}
+
+// ------------------------- RECENT TEST RUNS -------------------------------------- //
+.recent-runs {
+  .recent-runs-title {
+    text-align: left;
+    font-size: 24px;
+    border-bottom: 1px solid $structure;
+    margin-bottom: 15px;
+
+    .failures-count {
+      color: $brand-accent;
+    }
+  }
+  .recent-runs-container {
+    width: 100%
+  }
+  tr {
+    cursor: pointer;
+
+  }
+
+  td {
+    padding-bottom: 5px;
+    font-size: 0.9em;
+    color: #4a6e98;
+  }
+
+
 }

--- a/app/views/servers/_test_run_report.html.erb
+++ b/app/views/servers/_test_run_report.html.erb
@@ -5,7 +5,24 @@
   <div class="server-history server-history-loading">
   </div>
   <div class="failures row">
-    <div class="common-failures col-sm-12">
+    <div class="common-failures col-sm-6">
+      <div class="failures-title">
+        Recent Common Failures
+      </div>
+      <div>
+        <br><br>
+        Loading
+      </div>
+    </div>
+    <div class="recent-runs col-sm-6">
+      <div class="recent-runs-title">
+        Recent Test Runs
+      </div>
+      <div>
+        <br><br>
+        Loading
+      </div>
+    
     </div>
   </div>
 </div>


### PR DESCRIPTION
![recent_runs](https://cloud.githubusercontent.com/assets/412901/26209815/d94c2a7a-3bbb-11e7-8b54-00f6b4061c25.png)

When you hover over a row, an explanation for S and N comes up.  I'm not super happy with the styling, but we can go back later to refine (any recommendations are welcome now though).

When you click on a run it should open the test tab and load the test run.  When you do a new test run it should be automatically reflected in this list as well.