### PR TITLE
Fix scorecard display issue with completeness and cvx_meds rubrics

### DIFF
--- a/app/views/scorecards/index.html.erb
+++ b/app/views/scorecards/index.html.erb
@@ -214,19 +214,20 @@
             <div class="scorecard-table">
 
               <% scorecard.each do |key,value| %>
-                <% next if key=="points" or key==:points %>
+                <% rubric_name = key.to_s %>
+                <% next if rubric_name == 'points' %>
                 <% max_points = 10.0 %>
-                <% max_points = 20.0 if key==:completeness %>    
+                <% max_points = 20.0 if rubric_name == 'completeness' %>
                 <% index = (value[:points].to_f * (colors.length.to_f / max_points) ).to_i  %>
                 <% index -= 1 if index > 0 %>
-                <% index = (colors.length - index - 1) if key==:cvx_medications %>
+                <% index = (colors.length - index - 1) if rubric_name == 'cvx_medications' %>
                 <% color = colors[ index ]  %>
                 <div class="scorecard-row">
                   <!-- <td style="text&#45;align: center; background&#45;clip: padding&#45;box; background&#45;color: <%=color%>; color: white; border: 15px solid <%= color %>; border&#45;radius: 15px;"><%= value[:points].to_s %></td> -->
                   <div class="scorecard-score" style="background-color: <%=color%>"><%= value[:points].to_s %></div>
                   <div class="scorecard-rubric">
                     <div class="scorecard-name">
-                      <%= key.to_s.gsub('_',' ') %>
+                      <%= rubric_name.gsub('_',' ') %>
                     </div>
                     <div class="scorecard-out-of">
                       out of <%= max_points %> points


### PR DESCRIPTION
Fixes a display issue where Completeness and CVX Medications rubrics did not display the correct background behind the score. Immediately after scoring the bundle, the keys in the scorecard are symbols, but when fetching from the database later the keys are strings.