### PR TITLE
Multiversion Test Data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0',          group: :doc
 
 # gem 'fhir_models', :git => 'https://github.com/fhir-crucible/fhir_models.git'
-# gem 'fhir_client', :git => 'https://github.com/fhir-crucible/fhir_client.git'
+gem 'fhir_client', :git => 'https://github.com/fhir-crucible/fhir_client.git', :branch => 'multiversion'
 # gem 'fhir_client', :path => '../fhir_client'
 
 gem 'plan_executor', :git => 'https://github.com/fhir-crucible/plan_executor.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,20 @@
 GIT
+  remote: https://github.com/fhir-crucible/fhir_client.git
+  revision: 825997e6ba3c000f48ed7299fbdfca66064698cc
+  branch: multiversion
+  specs:
+    fhir_client (3.0.1)
+      activesupport (>= 3)
+      addressable (>= 2.3)
+      fhir_dstu2_models
+      fhir_models (>= 3.0.0)
+      nokogiri
+      oauth2 (~> 1.1)
+      rack (>= 1.5)
+      rest-client (~> 2.0)
+      tilt (>= 1.1)
+
+GIT
   remote: https://github.com/fhir-crucible/fhir_scorecard.git
   revision: edb5923484da63df4b0a68b7379e9511fc54d581
   specs:
@@ -21,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/synthetichealth/synthea.git
-  revision: 029055da5aab8de4cec580f04ce94484d1a973f9
+  revision: b6a7b0249ca622f46616364720994b9cfca4eee2
   specs:
     synthea (1.2.0)
       area
@@ -30,6 +46,7 @@ GIT
       distribution (~> 0.7.3)
       faker (~> 1.6, >= 1.6.0)
       fhir_client (>= 3.0.1)
+      fhir_dstu2_models
       fhir_models (>= 3.0.1)
       georuby
       highline
@@ -143,15 +160,6 @@ GEM
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     ffi (1.9.18)
-    fhir_client (3.0.2)
-      activesupport (>= 3)
-      addressable (>= 2.3)
-      fhir_models (>= 3.0.0)
-      nokogiri
-      oauth2 (~> 1.1)
-      rack (>= 1.5)
-      rest-client (~> 2.0)
-      tilt (>= 1.1)
     fhir_dstu2_models (1.0.2)
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
@@ -305,10 +313,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (12.0.0)
     rb-fsevent (0.9.8)
-    rb-inotify (0.9.9)
-      ffi (~> 1.0)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
     rdoc (4.3.0)
-    recursive-open-struct (1.0.4)
+    recursive-open-struct (1.0.5)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -384,6 +392,7 @@ DEPENDENCIES
   date_time_precision
   delayed_job_mongoid
   devise
+  fhir_client!
   fhir_scorecard!
   guard-livereload
   handlebars_assets (= 0.16)

--- a/app/controllers/synthea_controller.rb
+++ b/app/controllers/synthea_controller.rb
@@ -73,7 +73,7 @@ class SyntheaController < ApplicationController
         end
       end
       SyntheaRun.new(url: server_url, format: format_type, count: quantity, date: Time.now, success: count > 0).save
-      @notice = "Successfully loaded #{count} of #{quantity} record(s)." if count > 0
+      @notice = "Successfully loaded #{count} of #{quantity} #{fhir_version.upcase} record(s)." if count > 0
     rescue Exception => e 
       @message = "Failed to load records."
       @error = "Unexpected error: #{e.message}"

--- a/app/views/synthea/index.html.erb
+++ b/app/views/synthea/index.html.erb
@@ -33,14 +33,21 @@
 
                 </div>                
                 <div class="row" style="margin: 10px">
-                  <div class="col-sm-3">
+                  <div class="col-sm-2">
                     Format
                     <select required name="format_type">
                       <option value="json">JSON</option>
                       <option value="xml">XML</option>
                     </select>
                   </div>
-                  <div class="col-sm-5">
+                  <div class="col-sm-3">
+                    FHIR Version
+                    <select required name="fhir_version">
+                      <option value="dstu2">DSTU2</option>
+                      <option selected value="stu3">STU3</option>
+                    </select>
+                  </div>
+                  <div class="col-sm-3">
                     Number of Records
                     <select required name="quantity">
                       <option value="1">1</option>


### PR DESCRIPTION
Adds the ability to use either STU3 or DSTU2 on the Test Data loader. 

Adds a 3rd dropdown to the UI (because I love dropdowns) which pushes the dropdowns themselves onto a second row beneath their labels:
![version_dropdown](https://user-images.githubusercontent.com/13512036/27339422-d119d4fc-55a5-11e7-9dea-7a931986ffcf.JPG)


Tested successfully against HAPI FHIR DSTU2 and STU3. 


Note that this uses the 'multiversion' branch of the fhir_client. I can update this once that's merged.