### PR TITLE
SMART Launch Session Storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem "non-stupid-digest-assets"
 gem 'delayed_job_mongoid'
 gem 'daemons'
 gem 'time_difference'
-gem 'activerecord-session_store'
+gem 'mongo_session_store-rails4'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "non-stupid-digest-assets"
 gem 'delayed_job_mongoid'
 gem 'daemons'
 gem 'time_difference'
+gem 'activerecord-session_store'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,12 +93,6 @@ GEM
       activemodel (= 4.2.4)
       activesupport (= 4.2.4)
       arel (~> 6.0)
-    activerecord-session_store (1.1.0)
-      actionpack (>= 4.0, < 5.2)
-      activerecord (>= 4.0, < 5.2)
-      multi_json (~> 1.11, >= 1.11.2)
-      rack (>= 1.5.2, < 3)
-      railties (>= 4.0, < 5.2)
     activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -111,7 +105,7 @@ GEM
     area (0.10.0)
       fastercsv (~> 1.5)
     arel (6.0.4)
-    autoprefixer-rails (7.1.4.1)
+    autoprefixer-rails (7.1.5)
       execjs
     bcp47 (0.3.3)
       i18n
@@ -201,7 +195,7 @@ GEM
       multi_json
       sprockets (>= 2.0.3)
       tilt
-    hashdiff (0.3.6)
+    hashdiff (0.3.7)
     highline (1.7.8)
     hike (1.2.3)
     http-cookie (1.0.3)
@@ -239,6 +233,8 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
+    mongo_session_store-rails4 (6.0.0)
+      actionpack (>= 3.1)
     mongoid (4.0.2)
       activemodel (~> 4.0)
       moped (~> 2.0.0)
@@ -382,7 +378,7 @@ GEM
     unf_ext (0.0.7.4)
     warden (1.2.7)
       rack (>= 1.0)
-    webmock (3.0.1)
+    webmock (3.1.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -392,7 +388,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
-  activerecord-session_store
   addressable
   autoprefixer-rails
   bcp47
@@ -409,6 +404,7 @@ DEPENDENCIES
   magic_lamp
   minitest
   minitest-reporters
+  mongo_session_store-rails4
   mongoid (>= 4.0.0, < 5)
   mongoid-history
   nokogiri
@@ -433,4 +429,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.16.0.pre.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/synthetichealth/synthea.git
-  revision: cf93729d0d2ef4428d3d67a3deff165fd6c4f40f
+  revision: d65456df6e59629f974172777e2b2613336e5ac2
   specs:
     synthea (1.2.0)
       area
@@ -105,7 +105,7 @@ GEM
     area (0.10.0)
       fastercsv (~> 1.5)
     arel (6.0.4)
-    autoprefixer-rails (7.1.3)
+    autoprefixer-rails (7.1.4.1)
       execjs
     bcp47 (0.3.3)
       i18n
@@ -128,6 +128,7 @@ GEM
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    crass (1.0.2)
     daemons (1.2.4)
     date_time_precision (0.8.1)
     delayed_job (4.1.3)
@@ -213,7 +214,8 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.0.3)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)
     magic_lamp (1.8.1)
@@ -222,11 +224,11 @@ GEM
       rake
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
-    method_source (0.8.2)
+    method_source (0.9.0)
     mime-types (2.99.3)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
-    minitest-reporters (1.1.17)
+    minitest-reporters (1.1.18)
       ansi
       builder
       minitest (>= 5.0)
@@ -236,7 +238,7 @@ GEM
       moped (~> 2.0.0)
       origin (~> 2.1)
       tzinfo (>= 0.3.37)
-    mongoid-compatibility (0.4.1)
+    mongoid-compatibility (0.5.0)
       activesupport
       mongoid (>= 2.0)
     mongoid-history (0.6.1)
@@ -256,8 +258,8 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
     netrc (0.11.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     nokogiri-diff (0.2.0)
       nokogiri (~> 1.5)
       tdiff (~> 0.3, >= 0.3.2)
@@ -276,10 +278,9 @@ GEM
     origin (2.3.1)
     orm_adapter (0.5.0)
     pickup (0.0.11)
-    pry (0.10.4)
+    pry (0.11.1)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
+      method_source (~> 0.9.0)
     pry-byebug (3.5.0)
       byebug (~> 9.1)
       pry (~> 0.10)
@@ -311,7 +312,7 @@ GEM
       activesupport (= 4.2.4)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (12.0.0)
+    rake (12.1.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -325,7 +326,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     ruby-graphviz (1.2.3)
-    ruby-progressbar (1.8.1)
+    ruby-progressbar (1.8.3)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
     sass (3.2.19)
@@ -342,12 +343,11 @@ GEM
       actionmailer (>= 3.2.6, < 5)
       actionpack (>= 3.2.6, < 5)
       devise (~> 3.2)
-    simplecov (0.15.0)
+    simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    slop (3.6.0)
     sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -426,4 +426,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.4
+   1.16.0.pre.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/synthetichealth/synthea.git
-  revision: d65456df6e59629f974172777e2b2613336e5ac2
+  revision: 01d01d675c68502483be0eb37fb293bba5371d7f
   specs:
     synthea (1.2.0)
       area
@@ -93,6 +93,12 @@ GEM
       activemodel (= 4.2.4)
       activesupport (= 4.2.4)
       arel (~> 6.0)
+    activerecord-session_store (1.1.0)
+      actionpack (>= 4.0, < 5.2)
+      activerecord (>= 4.0, < 5.2)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0, < 5.2)
     activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -207,7 +213,7 @@ GEM
       multi_json (>= 1.2)
     json (1.8.6)
     jsonapi-renderer (0.1.3)
-    jsonpath (0.8.7)
+    jsonpath (0.8.8)
       multi_json
     jwt (1.5.6)
     listen (3.1.5)
@@ -326,7 +332,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     ruby-graphviz (1.2.3)
-    ruby-progressbar (1.8.3)
+    ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
     sass (3.2.19)
@@ -386,6 +392,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  activerecord-session_store
   addressable
   autoprefixer-rails
   bcp47

--- a/app/controllers/smarts_controller.rb
+++ b/app/controllers/smarts_controller.rb
@@ -467,18 +467,9 @@ class SmartsController < ApplicationController
 
   # Add a smart_client to the database or update existing
   def add_client(name,client_id,scopes)
-    client = nil
-    # Search for smart_client with name
-    SmartClient.all.each do |other|
-      if other.name == name
-        client = other
-        break
-      end
-    end
+    client = SmartClient.find_by(name: name) rescue nil
     # Create new smart_client if none exist
-    if client.nil?
-      client = SmartClient.new
-    end
+    client = SmartClient.new if client.nil?
     client.name = name
     client.client_id = client_id
     client.scopes = scopes
@@ -487,8 +478,8 @@ class SmartsController < ApplicationController
 
   # Delete a smart_client from the database
   def delete_client(name)
-    client = SmartClient.find_by(name: name)
-    client.destroy if client
+    client = SmartClient.find_by(name: name) rescue nil
+    client.destroy unless client.nil?
   end
 
   private

--- a/app/controllers/smarts_controller.rb
+++ b/app/controllers/smarts_controller.rb
@@ -465,18 +465,23 @@ class SmartsController < ApplicationController
     rows
   end
 
-  # Add a smart_client to the database
+  # Add a smart_client to the database or update existing
   def add_client(name,client_id,scopes)
-    client = SmartClient.new
+    client = nil
+    # Search for smart_client with name
+    SmartClient.all.each do |other|
+      if other.name == name
+        client = other
+        break
+      end
+    end
+    # Create new smart_client if none exist
+    if client.nil?
+      client = SmartClient.new
+    end
     client.name = name
     client.client_id = client_id
     client.scopes = scopes
-    # Destroy smart_client if it shares new smart_client name
-    SmartClient.all.each do |other|
-      unless other == client
-        other.destroy if other.name == client.name
-      end
-    end
     client.save
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,7 @@ require "action_mailer/railtie"
 require "rails/test_unit/railtie"
 require "sprockets/railtie" # Uncomment this line for Rails 3.1+
 require "fhir_scorecard"
+require "active_record"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,7 +62,7 @@ module Crucible
 
     # Configuration to set SMART on FHIR base url and redirect url
     config.smart_base_url = ''
-    config.smart_redirect_url = 'https://projectcrucible.org/smart/app'
+    config.smart_redirect_url = 'http://localhost:3000/smart/app'
 
     FHIR::Terminology.set_terminology_root(Rails.root.join('terminology').to_s)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,7 +7,6 @@ require "action_mailer/railtie"
 require "rails/test_unit/railtie"
 require "sprockets/railtie" # Uncomment this line for Rails 3.1+
 require "fhir_scorecard"
-require "active_record"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -63,8 +62,8 @@ module Crucible
 
     # Configuration to set SMART on FHIR base url and redirect url
     config.smart_base_url = ''
-    config.smart_redirect_url = 'http://localhost:3000/smart/app'
-
+    config.smart_redirect_url = 'https://projectcrucible.org/smart/app'
+    
     FHIR::Terminology.set_terminology_root(Rails.root.join('terminology').to_s)
 
   end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_crucible_session'
+Rails.application.config.session_store :active_record_store, :key => '_crucible_session'

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :active_record_store, :key => '_crucible_session'
+Rails.application.config.session_store :mongoid_store, :key => '_crucible_session'

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,7 +1,7 @@
 development:
   sessions:
     default:
-      database: crucible_development
+      database: crucible_09_26
       hosts:
         - localhost:27017
 test:

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,7 +1,7 @@
 development:
   sessions:
     default:
-      database: crucible_09_26
+      database: crucible_development
       hosts:
         - localhost:27017
 test:


### PR DESCRIPTION
When launching the SMART app from certain sandboxes/launchpads, there was a cookie overflow error causing the launch to fail. This is because certain sandboxes/launchpads have extremely large access tokens. Because the session information was configured to use cookie storage, this caused an overflow.

This PR switches session storage to use Mongoid in order to prevent any possible cookie overflow error.

Additionally, there was a small fix to updating config information for smart_client -- Now the existing smart_client is updated instead of adding a new one and deleting the previous one.