### PR TITLE
Update fhir_client.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/fhir-crucible/plan_executor.git
-  revision: 330d2952a4c59b18c3b10d4aa6d7edbad490896b
+  revision: 140ca2bd2897f990ec1c774f87c6f3dca47ad3d9
   specs:
     plan_executor (1.8.0)
       bcp47
@@ -140,7 +140,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     ffi (1.9.25)
-    fhir_client (3.1.1)
+    fhir_client (3.1.2)
       activesupport (>= 3)
       addressable (>= 2.3)
       fhir_dstu2_models (>= 1.0.4)


### PR DESCRIPTION
Update the fhir_client to [v3.1.2](https://github.com/fhir-crucible/fhir_client/releases/tag/v3.1.2), which includes a couple of bug fixes.