### PR TITLE
Minor fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'synthea', :git => 'https://github.com/synthetichealth/synthea.git', :branch
 #gem 'synthea', :path => '../synthea'
 
 gem 'mongoid', '>= 4.0.0', '< 5' # lock mongoid below 5 for the moment, as it requires code changes
-gem 'autoprefixer-rails'
+# gem 'autoprefixer-rails'
 gem 'nokogiri'
 gem 'date_time_precision'
 gem 'rest-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,8 +94,6 @@ GEM
     area (0.10.0)
       fastercsv (~> 1.5)
     arel (6.0.4)
-    autoprefixer-rails (9.5.1)
-      execjs
     bcp47 (0.3.3)
       i18n
     bson (3.2.7)
@@ -385,7 +383,6 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   addressable
-  autoprefixer-rails
   bcp47
   coffee-rails (~> 4.0.0)
   daemons

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -29,7 +29,7 @@
     <div class="service-list-item">
       <h2>Test FHIR Conformance</h2>
       Crucible provides a comprehensive testing capability for <strong>FHIR DSTU2, STU3 and R4</strong>.
-      To get started, enter a publically accessible URL in the form below.
+      To get started, enter a FHIR URL in the form below.
 
     </div>
     <div class="service-list-item">


### PR DESCRIPTION
Removing autoprefixer because it requires an updated version of node but we don't use it.