### PR TITLE
Adds FHIR 3.0.2, 4.0.1

### DIFF
--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -312,23 +312,25 @@ class Server
 
           if ['1.0.2', '1.0.1', '1.0.0', '0.5.0', '0.4.0', '0.40'].include? version_abbreviated
             self.fhir_sequence = 'DSTU2'
-          elsif ['3.0.0', '3.0.1', '1.8.0', '1.6.0', '1.4.0', '1.2.0', '1.1.0'].include? version_abbreviated
+          elsif ['3.0.0', '3.0.1', '3.0.2', '1.8.0', '1.6.0', '1.4.0', '1.2.0', '1.1.0'].include? version_abbreviated
             self.fhir_sequence = 'STU3'
+          elsif ['4.0.0', '4.0.1'].include? version_abbreviated
+            self.fhir_sequence = 'R4'
           else # Set to most recent sequence and version if not STU3 or DSTU2
             self.fhir_sequence = 'R4'
-            self.fhir_version = '4.0.0'
+            self.fhir_version = '4.0.1'
           end
         rescue # Set to most recent sequence and version if unexpected input
           self.fhir_sequence = 'R4'
-          self.fhir_version = '4.0.0'
+          self.fhir_version = '4.0.1'
         end
       else # Set to most recent sequence and version if no conformance value
         self.fhir_sequence = 'R4'
-        self.fhir_version = '4.0.0'
+        self.fhir_version = '4.0.1'
       end
     else # Set to most recent sequence and version if no conformance
       self.fhir_sequence = 'R4'
-      self.fhir_version = '4.0.0'
+      self.fhir_version = '4.0.1'
     end
     self.save
   end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -51,7 +51,7 @@
 <div class="container main">
 
   <div class="alert alert-warning alert-dismissible" role="alert">
-    Crucible has been updated to test both FHIR DSTU2 (v.1.0.2), FHIR STU3 (v.3.0.1), FHIR R4 (v4.0.0).
+    Crucible has been updated to test both FHIR DSTU2 (v.1.0.2), FHIR STU3 (v.3.0.2), FHIR R4 (v4.0.1).
   </div>
 
 


### PR DESCRIPTION
FHIR Servers returning v3.0.2 in the metadata statement will show up as R4 and fail most tests.

Please let me know if there are other files/places that might be affected by this